### PR TITLE
CON-620: fix leader implicit-agree vote synthesis + vote-based rotation vectors (contract parity)

### DIFF
--- a/scripts/07_generate_consensus_vectors.py
+++ b/scripts/07_generate_consensus_vectors.py
@@ -87,10 +87,14 @@ def categorize(path):
     return "no_appeal"
 
 
-def pattern_name(path, total_rotations):
+def pattern_name(path, total_rotations, rotation_kind="timeout"):
     core = " -> ".join(n for n in path if n not in ("START", "END"))
     if total_rotations:
-        return f"{core} [rot:{total_rotations}]"
+        # [rot:N] = leader-timeout rotations (entries pay only the 50% comp);
+        # [vrot:N] = vote-based rotations (entries also pay their aligned
+        # validators per the backward rotation loop).
+        tag = "vrot" if rotation_kind == "vote" else "rot"
+        return f"{core} [{tag}:{total_rotations}]"
     return core
 
 
@@ -123,7 +127,7 @@ def leader_vote_string(vote):
     return normalize_vote(vote)
 
 
-def build_example(path, rotation_counts, addresses_pool, sender, appealant):
+def build_example(path, rotation_counts, addresses_pool, sender, appealant, rotation_kind="timeout"):
     transaction_results, budget = path_to_transaction_results(
         path=path,
         addresses=addresses_pool,
@@ -132,6 +136,7 @@ def build_example(path, rotation_counts, addresses_pool, sender, appealant):
         leader_timeout=LEADER_TIMEOUT,
         validators_timeout=VALIDATORS_TIMEOUT,
         rotation_counts=rotation_counts or {},
+        rotation_kind=rotation_kind,
     )
     fee_events, round_labels = process_transaction(
         addresses=addresses_pool,
@@ -206,7 +211,7 @@ def build_example(path, rotation_counts, addresses_pool, sender, appealant):
             )
 
     total_rotations = sum((rotation_counts or {}).values())
-    name = pattern_name(path, total_rotations)
+    name = pattern_name(path, total_rotations, rotation_kind)
     example = {
         "description": f"Test Case: {name}",
         "initialState": {"rounds": rounds_out, "sender": "sender"},
@@ -285,24 +290,30 @@ def main():
     for variant in generate_all_path_variants(
         paths, max_rotations=args.max_rotations, max_idle=0
     ):
-        try:
-            name, example = build_example(
-                variant.path,
-                variant.rotation_counts,
-                addresses_pool,
-                sender,
-                appealant,
-            )
-        except Exception as e:  # noqa: BLE001 - report and continue
-            errors.append((variant.path, variant.rotation_counts, str(e)[:150]))
-            continue
-        category = categorize(variant.path)
         total_rotations = sum((variant.rotation_counts or {}).values())
-        bucket = rot if total_rotations else base
-        max_examples = 1 if total_rotations else 2
-        if len(bucket[category][name]) < max_examples:
-            bucket[category][name].append(example)
-        counts[category] += 1
+        # Rotation variants are emitted in both flavors: leader-timeout
+        # rotations ([rot:N]) and vote-based rotations ([vrot:N]), which pay
+        # their entries' aligned validators per the backward rotation loop.
+        kinds = ("timeout", "vote") if total_rotations else ("timeout",)
+        for rotation_kind in kinds:
+            try:
+                name, example = build_example(
+                    variant.path,
+                    variant.rotation_counts,
+                    addresses_pool,
+                    sender,
+                    appealant,
+                    rotation_kind=rotation_kind,
+                )
+            except Exception as e:  # noqa: BLE001 - report and continue
+                errors.append((variant.path, variant.rotation_counts, str(e)[:150]))
+                continue
+            category = categorize(variant.path)
+            bucket = rot if total_rotations else base
+            max_examples = 1 if total_rotations else 2
+            if len(bucket[category][name]) < max_examples:
+                bucket[category][name].append(example)
+            counts[category] += 1
 
     def write_category(category, patterns, suffix):
         data = {

--- a/scripts/07_generate_consensus_vectors.py
+++ b/scripts/07_generate_consensus_vectors.py
@@ -366,7 +366,8 @@ def main():
                     continue
                 new_patterns = {}
                 for nm, pd in old["patterns"].items():
-                    core = nm.split(" [rot:")[0]
+                    rotation_kind = "vote" if " [vrot:" in nm else "timeout"
+                    core = nm.split(" [vrot:")[0].split(" [rot:")[0]
                     path = ["START"] + core.split(" -> ") + ["END"]
                     old_ex = pd["examples"][0] if pd.get("examples") else {}
                     rot_list = old_ex.get("rotations") or []
@@ -380,6 +381,7 @@ def main():
                             addresses_pool,
                             sender,
                             appealant,
+                            rotation_kind=rotation_kind,
                         )
                     except Exception as e:  # noqa: BLE001
                         errors.append((path, rotation_counts, str(e)[:150]))

--- a/src/fee_simulator/core/path_to_transaction.py
+++ b/src/fee_simulator/core/path_to_transaction.py
@@ -52,21 +52,29 @@ def create_majority_agree_votes(
 def create_majority_disagree_votes(
     size: int, addresses: List[str], offset: int = 0
 ) -> Dict[str, Vote]:
-    """Create votes where majority disagrees."""
+    """Create votes where majority disagrees.
+
+    The leader cannot vote against its own receipt: on-chain the proposal IS
+    the leader's implicit AGREE vote (the contracts derive it from
+    leaderRevealVote), so a disagree majority must come entirely from the
+    validators — majority_count of them — and the leader ends up non-aligned
+    (penalized as a validator while still earning the leader fee).
+    """
     votes = {
-        addresses[0]: ["LEADER_RECEIPT", "DISAGREE"],  # Leader
+        addresses[0]: ["LEADER_RECEIPT", "AGREE"],  # Leader (implicit agree)
     }
 
     # Calculate majority threshold (more than half)
     majority_count = (size // 2) + 1
 
-    # First majority_count-1 validators disagree (we already have leader disagreeing)
-    for i in range(1, min(majority_count, size)):
+    # majority_count validators disagree (the leader's implicit AGREE does not
+    # contribute to the disagree majority)
+    for i in range(1, min(majority_count + 1, size)):
         votes[addresses[i]] = "DISAGREE"
 
     # Rest of validators split between AGREE and TIMEOUT
-    for i in range(majority_count, size):
-        if (i - majority_count) % 2 == 0:
+    for i in range(majority_count + 1, size):
+        if (i - majority_count - 1) % 2 == 0:
             votes[addresses[i]] = "AGREE"
         else:
             votes[addresses[i]] = "TIMEOUT"
@@ -77,21 +85,27 @@ def create_majority_disagree_votes(
 def create_majority_timeout_votes(
     size: int, addresses: List[str], offset: int = 0
 ) -> Dict[str, Vote]:
-    """Create votes where majority times out."""
+    """Create votes where majority times out.
+
+    As with the disagree case, the leader's receipt is an implicit AGREE vote
+    (a leader that itself times out is the LEADER_TIMEOUT path, not a receipt
+    round), so the timeout majority must come from majority_count validators
+    and the leader ends up non-aligned.
+    """
     votes = {
-        addresses[0]: ["LEADER_RECEIPT", "TIMEOUT"],  # Leader
+        addresses[0]: ["LEADER_RECEIPT", "AGREE"],  # Leader (implicit agree)
     }
 
     # Calculate majority threshold (more than half)
     majority_count = (size // 2) + 1
 
-    # First majority_count-1 validators timeout (we already have leader timing out)
-    for i in range(1, min(majority_count, size)):
+    # majority_count validators time out
+    for i in range(1, min(majority_count + 1, size)):
         votes[addresses[i]] = "TIMEOUT"
 
     # Rest of validators split between AGREE and DISAGREE
-    for i in range(majority_count, size):
-        if (i - majority_count) % 2 == 0:
+    for i in range(majority_count + 1, size):
+        if (i - majority_count - 1) % 2 == 0:
             votes[addresses[i]] = "AGREE"
         else:
             votes[addresses[i]] = "DISAGREE"
@@ -132,6 +146,25 @@ def create_undetermined_votes(
         votes[addresses[validator_idx]] = "TIMEOUT"
         validator_idx += 1
 
+    return votes
+
+
+def create_vote_rotation_votes(
+    size: int, addresses: List[str], offset: int = 0
+) -> Dict[str, Vote]:
+    """Create votes for a vote-based rotation entry: the committee unanimously
+    rejects the leader's proposal (majority DISAGREE), rotating the leader.
+
+    Mirrors the on-chain vote-based rotation trigger. In the backward rotation
+    loop every disagreeing validator of the entry is aligned with the entry's
+    own result and earns its validator fee; the rotated-out leader earns the
+    50% compensation and is neither paid a validator fee nor penalized.
+    """
+    votes = {
+        addresses[0]: ["LEADER_RECEIPT", "AGREE"],  # Leader (implicit agree)
+    }
+    for i in range(1, size):
+        votes[addresses[i]] = "DISAGREE"
     return votes
 
 
@@ -277,6 +310,7 @@ def path_to_transaction_results(
     removed_addresses: set = None,
     rotation_counts: Optional[Dict[int, int]] = None,
     idle_config: Optional[Dict[int, int]] = None,
+    rotation_kind: str = "timeout",
 ) -> Tuple[TransactionRoundResults, TransactionBudget]:
     """
     Convert a TRANSITIONS_GRAPH path to TransactionRoundResults and TransactionBudget.
@@ -290,8 +324,12 @@ def path_to_transaction_results(
         validators_timeout: Validators timeout value
         removed_addresses: Set of addresses that have been slashed/removed
         rotation_counts: Optional mapping of round index (0-based, counting only normal
-            rounds) to number of leader timeout rotations before the final outcome.
-            E.g. {0: 2} means the first normal round has 2 timeouts before the final leader.
+            rounds) to number of leader rotations before the final outcome.
+            E.g. {0: 2} means the first normal round has 2 rotations before the final leader.
+        rotation_kind: How the intermediate rotations happen — "timeout" (the
+            leader never proposes; only the 50% compensation is due) or "vote"
+            (the committee unanimously rejects the proposal; the entry's
+            aligned validators are paid per the backward rotation loop).
         idle_config: Optional mapping of round index to number of idle validators.
             E.g. {0: 2} means 2 validators in the first round are IDLE.
 
@@ -428,22 +466,25 @@ def path_to_transaction_results(
             rotations_list = []
 
             if num_timeout_rotations > 0:
-                # Create timeout rotations before the final outcome
-                # Each timeout rotation uses the next leader from the address pool
+                # Create rotation entries before the final outcome. Each entry
+                # uses the next leader from the address pool; "timeout" entries
+                # carry no votes, "vote" entries carry a unanimous rejection.
+                make_rotation_votes = (
+                    create_vote_rotation_votes
+                    if rotation_kind == "vote"
+                    else create_leader_timeout_votes
+                )
                 for rot_idx in range(num_timeout_rotations):
                     # The leader for this rotation is the current first address
                     rot_leader_idx = rot_idx  # index within normal_addresses
                     if rot_leader_idx < len(normal_addresses):
-                        timeout_votes = create_leader_timeout_votes(
-                            len(normal_addresses), normal_addresses
-                        )
                         # Rotate addresses: put the rot_idx-th leader first
                         rot_addresses = normal_addresses[rot_idx:] + normal_addresses[:rot_idx]
-                        timeout_votes = create_leader_timeout_votes(
+                        rotation_votes = make_rotation_votes(
                             len(rot_addresses), rot_addresses
                         )
-                        rotations_list.append(Rotation(votes=timeout_votes))
-                        # Track this timed-out leader
+                        rotations_list.append(Rotation(votes=rotation_votes))
+                        # Track this rotated-out leader
                         previous_leaders.append(rot_addresses[0])
 
                 # Final rotation: shift addresses so next available leader is first

--- a/src/fee_simulator/core/path_to_transaction.py
+++ b/src/fee_simulator/core/path_to_transaction.py
@@ -346,6 +346,10 @@ def path_to_transaction_results(
         rotation_counts = {}
     if idle_config is None:
         idle_config = {}
+    if rotation_kind not in ("timeout", "vote"):
+        raise ValueError(
+            f"rotation_kind must be 'timeout' or 'vote', got {rotation_kind!r}"
+        )
 
     rounds = []
     appeals = []

--- a/tests/fee_distributions/simple_round_types_tests/test_normal_round.py
+++ b/tests/fee_distributions/simple_round_types_tests/test_normal_round.py
@@ -303,11 +303,19 @@ def test_normal_round_majority_disagree(verbose, debug):
     )
 
     # Leader Fees Assert
-    # In our implementation, the leader also disagrees (part of majority)
+    # The leader's receipt is an implicit AGREE vote (it cannot vote against
+    # its own proposal), so under a disagree majority the leader is
+    # non-aligned: it earns the leader fee but no validator fee, and is
+    # penalized as a validator — mirroring the on-chain contracts.
     assert (
-        compute_total_earnings(fee_events, addresses_pool[0])
-        == leaderTimeout + validatorsTimeout
-    ), "Leader should have 100 (leader) + 200 (validator) as part of majority"
+        compute_total_earnings(fee_events, addresses_pool[0]) == leaderTimeout
+    ), "Leader should earn only the leader fee when the majority disagrees"
+    leader_burns = sum(
+        e.burned for e in fee_events if e.burned and e.address == addresses_pool[0]
+    )
+    assert (
+        leader_burns == PENALTY_REWARD_COEFFICIENT * validatorsTimeout
+    ), "Leader should be penalized as a non-aligned validator"
 
     # Check that minority validators burn
     # Find validators who are in minority (those who agreed or timed out)


### PR DESCRIPTION
## Context

The consensus repo now compares fee results **per recipient** against these vectors (genlayer-consensus `con-609-integration-base`, `perRecipientParity.ts`): every leader fee, validator reward and penalty is asserted to the wei against the `FeesProcessor` ledgers and `ValidatorFeeDistributed`/`ValidatorPenaltyRecorded` events. That comparison surfaced three modeling divergences where the contracts follow the normative spec and the simulator did not. Evidence: genlayer-consensus#1156 discussion + measured on-chain ledgers cited below.

## Fix 1 — the leader can no longer vote against its own receipt

`create_majority_disagree_votes` / `create_majority_timeout_votes` synthesized the leader's vote as `["LEADER_RECEIPT", "DISAGREE"/"TIMEOUT"]`. On-chain that's impossible: the proposal **is** the leader's implicit AGREE vote (derived from `leaderRevealVote`). Consequences fixed:

- **Un-drivable majorities**: `MAJORITY_DISAGREE` vectors carried only 2 validator DISAGREE votes (leader made the 3rd) — per spec `09-fees-and-interface.md:344` (`floor(total/2)+1`, leader's receipt counted as agree) that composition is a tie, and no driven flow can reproduce the labeled outcome. Compositions now use `majority_count` **validator** votes.
- **Deposed leader mis-rewarded**: the leader landed in the majority and collected a validator reward (+200) on top of the leader fee. Measured contract behavior (majority-disagree, all-disagree final round): leader earns the 100 leader fee and is **penalized 200** as a non-aligned validator. With the corrected composition the existing distribution code lands exactly there — no distribution change needed.

## Fix 2 + 3 — vote-based rotation entries and vectors for them

Intermediate rotations were always synthesized as leader-timeout entries (comp-only), but the contracts' vote-based rotations (proposal rejected → rotate) additionally pay the entry's aligned validators per the normative spec (`09:245`: "Validators of the rotation entry ARE paid/penalized against the entry's own result"). `distribute_rotation_entry` already modeled this correctly (#19) — the entries just never existed in generated vectors.

- `path_to_transaction_results(..., rotation_kind="timeout"|"vote")`; vote entries = unanimous committee rejection of the leader.
- The vector generator emits both flavors: existing `[rot:N]` names unchanged (timeout), new **`[vrot:N]`** (vote-based).
- Sanity anchor: `LEADER_RECEIPT_MAJORITY_AGREE [vrot:1]` now totals **1,550** — matching the amount measured on the integrated contracts to the wei (final round 300+200+200, penalties 2×200, rotation entry 4×200, rotated-out comp 50).

## Tests

- `test_normal_round_majority_disagree` updated to the corrected semantics (leader: leader fee only + validator penalty).
- Full suite: **994 passed, 5 skipped**.

## Follow-up (consensus repo)

Regenerate `test/fees/simulator_results/*` with this generator so the consensus-side per-recipient suites can drop their `augmentWithRotationEntries` shim and consume `[vrot:N]` directly. Tracked under CON-609 / CON-131.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BUR8B9ozV6t4CnrMz4xYSC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a second rotation style to generated consensus scenarios, extending rotation-enabled pattern coverage.
  * Rotation-based outputs now clearly differentiate timeout-based vs vote-based variants in their names and regenerated examples keep the correct flavor.
* **Bug Fixes**
  * Updated vote/rotation logic for normal-round majority **DISAGREE** and **TIMEOUT** so the leader’s receipt is treated as an implicit **AGREE**, adjusting how leader rewards and burns are computed.
  * Updated related expectations in tests to reflect the corrected leader fee/burn behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->