### PR TITLE
fix: committee replacement on rotation + context-dependent MajorityTimeout labeling (CON-621)

### DIFF
--- a/src/fee_simulator/core/path_to_transaction.py
+++ b/src/fee_simulator/core/path_to_transaction.py
@@ -469,36 +469,55 @@ def path_to_transaction_results(
             num_idle = idle_config.get(normal_count, 0)
             rotations_list = []
 
+            round_participants = set(normal_addresses)
+
             if num_timeout_rotations > 0:
                 # Create rotation entries before the final outcome. Each entry
-                # uses the next leader from the address pool; "timeout" entries
-                # carry no votes, "vote" entries carry a unanimous rejection.
+                # is led by the committee's current first address; "timeout"
+                # entries carry no votes, "vote" entries carry a unanimous
+                # rejection.
                 make_rotation_votes = (
                     create_vote_rotation_votes
                     if rotation_kind == "vote"
                     else create_leader_timeout_votes
                 )
+                committee = list(normal_addresses)
                 for rot_idx in range(num_timeout_rotations):
-                    # The leader for this rotation is the current first address
-                    rot_leader_idx = rot_idx  # index within normal_addresses
-                    if rot_leader_idx < len(normal_addresses):
-                        # Rotate addresses: put the rot_idx-th leader first
-                        rot_addresses = normal_addresses[rot_idx:] + normal_addresses[:rot_idx]
-                        rotation_votes = make_rotation_votes(
-                            len(rot_addresses), rot_addresses
-                        )
-                        rotations_list.append(Rotation(votes=rotation_votes))
-                        # Track this rotated-out leader
-                        previous_leaders.append(rot_addresses[0])
+                    if not committee:
+                        break
+                    entry_leader = committee[0]
+                    rotation_votes = make_rotation_votes(
+                        len(committee), committee
+                    )
+                    rotations_list.append(Rotation(votes=rotation_votes))
+                    previous_leaders.append(entry_leader)
 
-                # Final rotation: shift addresses so next available leader is first
-                final_addresses = normal_addresses[num_timeout_rotations:] + normal_addresses[:num_timeout_rotations]
-                final_round = create_normal_round(node, final_addresses)
+                    # Committee replacement (on-chain RoundsCreation): the
+                    # rotated-out leader leaves the committee and a fresh
+                    # validator from the pool joins. The rotated-out leader
+                    # keeps only the 50% comp — never a final-round vote,
+                    # reward or penalty.
+                    replacement = None
+                    while next_unused_idx < len(addresses):
+                        cand = addresses[next_unused_idx]
+                        next_unused_idx += 1
+                        if cand not in removed_addresses:
+                            replacement = cand
+                            break
+                    committee = [a for a in committee if a != entry_leader]
+                    if replacement is not None:
+                        committee.append(replacement)
+                        round_participants.add(replacement)
+
+                # Final rotation votes over the replaced committee
+                final_round = create_normal_round(node, committee)
                 rotations_list.append(final_round.rotations[0])
                 round_obj = Round(rotations=rotations_list)
+                final_committee = committee
             else:
                 # No rotations, create a normal single-rotation round
                 round_obj = create_normal_round(node, normal_addresses)
+                final_committee = normal_addresses
 
             # Apply idle config: replace some validator votes with IDLE
             if num_idle > 0 and round_obj.rotations:
@@ -519,13 +538,9 @@ def path_to_transaction_results(
             rounds.append(round_obj)
 
             # Update state
-            cumulative_active.update(normal_addresses)
-            if normal_addresses and num_timeout_rotations == 0:
-                previous_leaders.append(normal_addresses[0])
-            elif normal_addresses and num_timeout_rotations > 0:
-                # The final leader is already not in previous_leaders, track them
-                final_leader = normal_addresses[num_timeout_rotations] if num_timeout_rotations < len(normal_addresses) else normal_addresses[0]
-                previous_leaders.append(final_leader)
+            cumulative_active.update(round_participants)
+            if final_committee:
+                previous_leaders.append(final_committee[0])
             normal_count += 1
 
             # Track majority for appeals (always from last rotation)

--- a/src/fee_simulator/core/round_labeling.py
+++ b/src/fee_simulator/core/round_labeling.py
@@ -189,6 +189,7 @@ def classify_appeal_round(
     round_index: int,
     rounds: List[Dict[str, Vote]],
     leader_addresses: List[Optional[str]],
+    prior_labels: Optional[List[RoundLabel]] = None,
 ) -> RoundLabel:
     """Classify an appeal round based on the previous round's outcome."""
     if round_index == 0:  # Safety check
@@ -218,7 +219,17 @@ def classify_appeal_round(
         orig_round, leader_addresses[original_round_index]
     )
 
-    if orig_leader_action == "LEADER_TIMEOUT":
+    # The appeal type follows what was appealed, not the submitted node name
+    # (FeesRecorder MajorityTimeout branch): a round colored LeaderTimeout —
+    # a receipt round with a validators-timeout majority after a successful
+    # leader appeal — is appealed as a leader-timeout appeal.
+    timeout_colored = (
+        prior_labels is not None
+        and original_round_index < len(prior_labels)
+        and prior_labels[original_round_index] == "LEADER_TIMEOUT_50_PERCENT"
+    )
+
+    if orig_leader_action == "LEADER_TIMEOUT" or timeout_colored:
         return classify_leader_timeout_appeal(round_index, rounds, leader_addresses)
     else:
         orig_majority = compute_majority(orig_round)
@@ -234,7 +245,10 @@ SPECIAL_CASE_PATTERNS = [
         "pattern": [
             "NORMAL_ROUND",
             ["APPEAL_LEADER_SUCCESSFUL", "APPEAL_VALIDATOR_SUCCESSFUL"],
-            "NORMAL_ROUND",
+            # The re-execution may itself be colored LeaderTimeout when it
+            # ends in a validators-timeout majority; the original round is
+            # skipped either way.
+            ["NORMAL_ROUND", "LEADER_TIMEOUT_50_PERCENT"],
         ],
         "changes": {0: "SKIP_ROUND"},
     },
@@ -425,7 +439,18 @@ def label_rounds(transaction_results: TransactionRoundResults) -> List[RoundLabe
 
         # Classify based on round type - check vote patterns instead of index
         if is_likely_appeal_round(round_votes, leader_addresses[i]):
-            label = classify_appeal_round(i, rounds, leader_addresses)
+            label = classify_appeal_round(i, rounds, leader_addresses, labels)
+        elif (
+            i > 0
+            and labels[i - 1] == "APPEAL_LEADER_SUCCESSFUL"
+            and leader_action == "LEADER_RECEIPT"
+            and compute_majority(round_votes) == "TIMEOUT"
+        ):
+            # FeesRecorder MajorityTimeout branch: a re-execution after a
+            # successful leader appeal that ends in a validators-timeout
+            # majority is colored LeaderTimeout (halved leader fee), not
+            # Normal. Round 0 with a timeout majority keeps NORMAL semantics.
+            label = "LEADER_TIMEOUT_50_PERCENT"
         else:
             is_only_round = total_rounds == 1
             label = classify_normal_round(leader_action, is_only_round)


### PR DESCRIPTION
## Context

Follow-up to #20. Feeding the regenerated vectors into the consensus repo's `fee_finalization_tests` (CON-609 per-recipient parity, `con-609-integration-base`) left failures traced to two remaining simulator modeling divergences from the contracts. Spec and contract references: [CON-621](https://linear.app/genlayer-labs/issue/CON-621/simulator-contract-parity-committee-replacement-on-rotation-context).

## Change 1 — Committee replacement on rotation

**On-chain** (`RoundsCreation`, spec 07): on rotation the old leader is removed and a new validator is added. Previously the simulator kept the same committee for rotation entries and the final round — the rotated-out leader stayed as a final-round voter and collected a reward/penalty there.

Now, after each rotation entry, the entry's leader leaves the committee and a fresh address from the pool joins; the final round votes over the replaced committee. The rotated-out leader keeps only the 50% comp — never a final-round vote, reward, or penalty. Applies to both `rotation_kind="timeout"` and `"vote"`, so `[rot:N]` and `[vrot:N]` vectors both gain one incoming participant per rotation.

**Validation anchor (met):** regenerated `[vrot:1]` MAJORITY_AGREE shows exactly the measured contract ledgers — final leader 500, two agree voters 400 each, one disagree voter 200 fees + 200 penalty, incoming validator 0 fees + 200 penalty, comp-holder 50 with no penalty; 6 participants, totals 1,550/400. This lets the consensus rotation suites consume `[vrot:N]` directly and delete `augmentWithRotationEntries`.

## Change 2 — MajorityTimeout labeling in post-appeal re-executions

**On-chain** (`FeesRecorder._updateRoundTypesBasedOnCurrentRoundResult`, `MajorityTimeout` branch — context-dependent):

- Round 0 with a timeout majority keeps NORMAL semantics — the simulator already matched; **no change**.
- A re-execution after a successful leader appeal ending in a validators-timeout majority is colored `LEADER_TIMEOUT_50_PERCENT` (halved leader fee; the existing `apply_leader_timeout_50_percent` distribution rule applies — no distribution change).
- A follow-up appeal on such a round is typed `APPEAL_LEADER_TIMEOUT_SUCCESSFUL/UNSUCCESSFUL`, not `VALIDATOR_APPEAL_*` — the appeal type follows what was appealed, not the submitted node name. The #19/#20 leader-timeout bond formula (priced at the induced committee, not the round+2 schedule) then applies automatically, since `compute_appeal_bond` routes on the appeal label.
- The `SKIP_ROUND` transformation accepts the LeaderTimeout-colored re-execution, so the original round is still skipped.

**Validation anchor (met):** `LEADER_RECEIPT_UNDETERMINED → LEADER_APPEAL_SUCCESSFUL → LEADER_RECEIPT_MAJORITY_TIMEOUT → VALIDATOR_APPEAL_UNSUCCESSFUL` now labels `SKIP_ROUND / APPEAL_LEADER_SUCCESSFUL / LEADER_TIMEOUT_50_PERCENT / APPEAL_LEADER_TIMEOUT_UNSUCCESSFUL`, and the regenerated complex-scenario vector carries these types.

## Tests

- Full simulator suite: **994 passed, 5 skipped** — no tests were pinned to the old semantics.
- Vectors regenerated (`--max-length 7 --max-rotations 2 --existing-dir`) and fed to `con-609-integration-base` (on top of `d7d31c3a`): `fee_finalization_tests` **220/222**.
- The 2 remaining RoundTypeColoring failures are consensus-side driver consumption: with the corrected vectors the driver still drives the follow-up appeal with validator-appeal semantics, so on-chain it succeeds (contract colors `SKIP / APPEAL_LEADER_TIMEOUT_SUCCESS / LEADER_TIMEOUT_150%`) instead of reproducing the unsuccessful leader-timeout appeal. Tracked in CON-621 alongside the `[vrot:N]`/`augmentWithRotationEntries` cleanup.

## Follow-up (consensus repo)

Regenerate `test/fees/simulator_results/*` with this generator after merge and update the RoundTypeColoring driver to drive appeals per the vector's appeal type. Tracked under CON-621 / CON-609.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FeEwcpMkc6yQLzqSaVCAV5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The fee simulator now handles timeout/vote rotation scenarios more realistically by tracking rotating participants across rounds.
  * Appeal and timeout rounds are now labeled more accurately, including a new timeout-related outcome for majority-timeout cases.

* **Bug Fixes**
  * Improved leader tracking after rotation rounds so later rounds reflect the correct final leader.
  * Updated special-case round classification so successful appeal flows can now end with either a normal round or a timeout-style round.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->