### PR TITLE
fix: NoMajority validator appeals succeed; unsuccessful timeout appeals must confirm (CON-610)

### DIFF
--- a/src/fee_simulator/core/path_to_transaction.py
+++ b/src/fee_simulator/core/path_to_transaction.py
@@ -258,16 +258,15 @@ def create_appeal_votes(
                     votes[addresses[offset + i]] = "DISAGREE"
                 for i in range(majority_count, size):
                     votes[addresses[offset + i]] = "AGREE"
-            else:  # TIMEOUT or UNDETERMINED
-                # For unsuccessful validator appeal after undetermined, maintain undetermined
-                # Create equal split to ensure no clear majority
-                third = size // 3
-                for i in range(third):
-                    votes[addresses[offset + i]] = "AGREE"
-                for i in range(third, 2 * third):
-                    votes[addresses[offset + i]] = "DISAGREE"
-                for i in range(2 * third, size):
+            else:  # TIMEOUT
+                # On-chain (Rounds.sol) an appeal against ValidatorsTimeout
+                # fails only when the appeal round CONFIRMS the outcome with
+                # a timeout majority; a NoMajority composition would make the
+                # appeal succeed. Synthesize a genuine confirming majority.
+                for i in range(majority_count):
                     votes[addresses[offset + i]] = "TIMEOUT"
+                for i in range(majority_count, size):
+                    votes[addresses[offset + i]] = "AGREE"
 
     return votes
 

--- a/src/fee_simulator/core/refunds.py
+++ b/src/fee_simulator/core/refunds.py
@@ -32,6 +32,18 @@ def compute_sender_refund(
     Note: `burned` on VALIDATOR events is a stake-level penalty, not a fee
     pot flow, so it does not participate here. Only APPEALANT burns (bond
     value the simulator destroys on fallback paths) reduce the pot.
+
+    Contrast with the contracts (FeesProcessor): on-chain the refund bucket
+    (feesToReturnToUser) is ACCRUED flow-by-flow — skip-round fees, bond
+    residues, leader-fee halves, and penalties recorded with
+    returnToUser=true are each credited explicitly. The simulator reaches
+    the same economics implicitly: a penalized validator simply never earns
+    its fee allocation, so that money stays in the pot and lands in this
+    residue-based refund. Any constant delta between this refund and the
+    contract's bucket therefore points to an accrual the contract retains
+    or redistributes (returnToUser=false paths, dust) rather than to a
+    penalty flowing to the sender here — validator penalty burns never
+    enter this refund.
     """
     # TODO: when introducing toppers, we need to change this function
 

--- a/src/fee_simulator/core/round_labeling.py
+++ b/src/fee_simulator/core/round_labeling.py
@@ -178,8 +178,11 @@ def classify_vote_appeal(
 
     # Validator appeal: previous round had a clear majority
     else:
-        # Successful if validators changed the outcome
-        if appeal_majority != prev_majority and appeal_majority != "UNDETERMINED":
+        # On-chain (Rounds.sol) an appeal fails only when the appeal round
+        # CONFIRMS the original outcome with a matching majority. A
+        # NoMajority appeal round confirms nothing — the appeal succeeds and
+        # the transaction goes back for re-execution.
+        if appeal_majority != prev_majority:
             return "APPEAL_VALIDATOR_SUCCESSFUL"
         else:
             return "APPEAL_VALIDATOR_UNSUCCESSFUL"

--- a/tests/round_labeling/test_chained_unsuccessful_appeals.py
+++ b/tests/round_labeling/test_chained_unsuccessful_appeals.py
@@ -81,7 +81,10 @@ class TestChainedUnsuccessfulAppeals:
                         )
                     ]
                 ),
-                # Round 3: Second appeal (validators still agree - unsuccessful)
+                # Round 3: Second appeal (validators still agree - unsuccessful).
+                # An appeal is unsuccessful only when it CONFIRMS the original
+                # outcome with a matching majority (4/6 AGREE here); a
+                # NoMajority composition would make the appeal succeed.
                 Round(
                     rotations=[
                         Rotation(
@@ -89,9 +92,9 @@ class TestChainedUnsuccessfulAppeals:
                                 addresses_pool[13]: "AGREE",
                                 addresses_pool[14]: "AGREE",
                                 addresses_pool[15]: "AGREE",
-                                addresses_pool[16]: "DISAGREE",
+                                addresses_pool[16]: "AGREE",
                                 addresses_pool[17]: "DISAGREE",
-                                addresses_pool[18]: "TIMEOUT",
+                                addresses_pool[18]: "DISAGREE",
                             }
                         )
                     ]


### PR DESCRIPTION
## Context

Third parity PR (same treatment as #20/#21), stacked on #21. The CON-610 per-recipient upgrade of `ValidatorAppealUnsuccessful` found a verified divergence (genlayer-consensus `2348e8ea`, empirically driven on-chain): the MAJORITY_TIMEOUT variant's vector encoded the appeal round as 2A/2D/3T — a NoMajority composition — treated it as an unsuccessful appeal, and equal-split 400×7 to everyone. Under the contracts (`Rounds.sol`), an appeal against a `ValidatorsTimeout` fails **only when the appeal round confirms the original outcome with a timeout majority (≥4 of 7)**; a NoMajority round confirms nothing, so the appeal *succeeds* (transaction back to Proposing). And when an appeal genuinely fails, the payout is not an equal split — bond plus the appeal round's fee pool go to the **aligned voters only**, the rest penalized. Spec: [CON-610](https://linear.app/genlayer-labs/issue/CON-610/numerical-fee-parity-validator-appeals-successful-unsuccessful) comments.

## Fix 1 — vote synthesis (mirrors #20's pattern)

`create_appeal_votes` now synthesizes unsuccessful validator appeals after a timeout round as a genuine confirming majority (4 TIMEOUT / 3 AGREE) instead of the equal 1/3 split. With a real majority, the existing distribution code already lands exactly on the measured contract ledgers — 4 aligned × 700 (bond 1,400 + appeal fee pool 1,400, split 4 ways), 3 misaligned × −200 — no distribution change needed. The simulator already modeled aligned-only redistribution correctly for the AGREE variant; the defect was solely the generator accepting a NoMajority composition as "unsuccessful".

## Fix 2 — labeling: NoMajority appeal = successful → re-execution

`classify_vote_appeal` treated an UNDETERMINED appeal majority as unsuccessful. An appeal now fails **only** when the appeal majority matches the appealed round's majority; a NoMajority appeal classifies as `APPEAL_VALIDATOR_SUCCESSFUL` (re-execution follows), per the contract rule.

`test_double_validator_unsuccessful_appeal` hand-built its second "unsuccessful" appeal as 3A/2D/1T (NoMajority) — updated to a confirming 4/6 AGREE majority to preserve its intent.

## The 80-wei refund question — simulator-side answer

Documented in `compute_sender_refund` (refunds.py): the simulator's refund is a **pot residue** (`total_cost + bonds − Σ earned − appellant burns`); validator penalty `burned` amounts are stake-level slashes destroyed outside the fee pot and **never flow to the sender**. The economics of the contracts' `_recordValidatorPenalty(..., returnToUser=true)` credits are reached implicitly — a penalized validator never earns, so its unearned fee allocation stays in the pot and lands in the refund. The contract bucket, by contrast, is accrued flow-by-flow (`FeesProcessor.sol:263/338/353/392/856`). A constant delta between the two therefore points at a contract-side accrual difference (`returnToUser=false` redistribution paths, retained dust, or quote composition) — not at a penalty flowing to the sender in the simulator. Recommended next step on the consensus side: decompose the case's `feesToReturnToUser` accrual events against the sim pot decomposition (for the FullIntegration case: 6,050 = 3,400 normal rounds + 1,500 appeal round + 1,150 worst-case appeal-reward reserve; refund 3,250 = 7,450 − 4,200).

## Validation

- Simulator suite: **994 passed, 5 skipped**.
- Regenerated vectors (`--max-length 7 --max-rotations 2 --existing-dir`) fed to `con-609-integration-base` (on `2348e8ea`, which asserts the ratified contract semantics for this exact variant): `ValidatorAppealUnsuccessful` green, full `fee_finalization_tests` **222/222**.
- The regenerated `LEADER_RECEIPT_MAJORITY_TIMEOUT → VALIDATOR_APPEAL_UNSUCCESSFUL` vector now encodes 4T/3A with 4 × 700 aligned rewards — the consensus suite's in-code divergence note can be dropped.

## Follow-up (consensus repo)

Commit the regenerated vectors and drop the divergence documentation in `ValidatorAppealUnsuccessful`; use the refund-model answer above to decide the exact refund-leg assertion for the FullIntegration pilot. Tracked under CON-610.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FeEwcpMkc6yQLzqSaVCAV5