### PR TITLE
fix: retro-skip the appealed round when the re-execution is a leader timeout (CON-610)

### DIFF
--- a/src/fee_simulator/core/round_labeling.py
+++ b/src/fee_simulator/core/round_labeling.py
@@ -248,10 +248,11 @@ SPECIAL_CASE_PATTERNS = [
         "pattern": [
             "NORMAL_ROUND",
             ["APPEAL_LEADER_SUCCESSFUL", "APPEAL_VALIDATOR_SUCCESSFUL"],
-            # The re-execution may itself be colored LeaderTimeout when it
-            # ends in a validators-timeout majority; the original round is
-            # skipped either way.
-            ["NORMAL_ROUND", "LEADER_TIMEOUT_50_PERCENT"],
+            # The contract retro-skips the appealed round on a successful
+            # appeal regardless of how the re-execution ends
+            # (FeesRecorder): a normal outcome, a validators-timeout
+            # majority colored LeaderTimeout, or a genuine leader timeout.
+            ["NORMAL_ROUND", "LEADER_TIMEOUT_50_PERCENT", "LEADER_TIMEOUT"],
         ],
         "changes": {0: "SKIP_ROUND"},
     },


### PR DESCRIPTION
## Context

Fourth parity PR, stacked on #22. The CON-610 re-execution-variant pass (genlayer-consensus `e575d01a`) found the last simulator divergence in the validator-appeal family: the LeaderTimeout chain's vector kept round 0 **paid**, but the contract retro-skips round 0 after a successful validator appeal **regardless of how the re-execution ends** — verified by the driven coloring `SKIP / APPEAL_VALIDATOR_SUCCESS / LEADER_TIMEOUT_50%`.

## The defect

`label_rounds` runs the "Skip round before successful appeal" pattern before post-processing, so a genuine `LEADER_TIMEOUT` re-execution is still labeled `LEADER_TIMEOUT` (not yet `LEADER_TIMEOUT_50_PERCENT`) when the pattern is evaluated — the third slot never matched and round 0 stayed `NORMAL_ROUND`.

## The fix

One line in the pattern: the re-execution slot now accepts `LEADER_TIMEOUT` alongside `NORMAL_ROUND` and `LEADER_TIMEOUT_50_PERCENT`, for both successful appeal types. Result for `... → APPEAL_*_SUCCESSFUL → LEADER_TIMEOUT` chains:

- labels: `SKIP_ROUND / APPEAL_*_SUCCESSFUL / LEADER_TIMEOUT_50_PERCENT`
- round 0 unpaid; the timed-out re-execution leader keeps only the 50 comp; the forfeited allocation flows to the sender via the pot residue (matching the consensus finding that the forfeited half returns through `leftOverFees`, not the refund bucket) — e.g. the `MAJORITY_AGREE → VALIDATOR_APPEAL_SUCCESSFUL → LEADER_TIMEOUT` vector's `net_change` is now 4,500.

## Validation

- Simulator suite: **994 passed, 5 skipped**.
- Regenerated vectors (`--max-length 7 --max-rotations 2 --existing-dir`) fed to `con-609-integration-base` (on `e575d01a`): full `fee_finalization_tests` **222/222**. The LeaderTimeout variant's round-0 SKIP-semantics fallback and its in-code divergence note can be dropped — the vector now encodes `SKIP / VALIDATOR_APPEAL_SUCCESSFUL / LEADER_TIMEOUT_50%` directly.

## Follow-up (consensus repo)

Commit the regenerated vectors and drop the divergence note in `ValidatorAppealSuccessful.LeaderTimeout`. Tracked under CON-610.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FeEwcpMkc6yQLzqSaVCAV5