### PR TITLE
fix: include the leader in the EQUAL_SPLIT pool (CON-611)

### DIFF
--- a/src/fee_simulator/core/round_fee_distribution/equal_split.py
+++ b/src/fee_simulator/core/round_fee_distribution/equal_split.py
@@ -26,12 +26,16 @@ def apply_equal_split(
     - Previous round was APPEAL_LEADER_UNSUCCESSFUL
     - Current round has UNDETERMINED majority
 
-    Fee distribution (contract: _distributeFeesToValidators with
-    skipLeader=true, distributeToAll=true, extra=previousAppealBond):
-    - Leader: earns leaderTimeout only (excluded from the validator pool)
-    - ALL non-leader validators: earn validatorsTimeout + an equal share of
-      the previous appeal bond (no penalties)
+    Fee distribution (contract: bond + round budget divided across ALL
+    committee members, leader included, plus the leader fee — measured on
+    the driven flows, CON-611):
+    - Pool = previous appeal bond + committee_size * validatorsTimeout
+    - EVERY committee member (leader included) earns pool // committee_size
+      as its validator share (no penalties) — same as the round-0
+      undetermined treatment, which also pays the leader's validator share
+    - Leader additionally earns leaderTimeout
     - The bond is NOT returned to the sender; the division remainder is
+      (1 wei dust on an 11-member split)
     """
     events = []
     round_obj = transaction_results.rounds[round_index]
@@ -72,11 +76,13 @@ def apply_equal_split(
             appeal_round_index=round_index - 1,
         )
 
-    validator_addresses = [addr for addr in votes if addr != first_addr]
-    bond_share = split_amount(appeal_bond, len(validator_addresses))
+    # Bond + full round budget split equally across ALL committee members,
+    # leader included; the division remainder flows back to the sender.
+    committee = list(votes.keys())
+    pool = appeal_bond + len(committee) * budget.validatorsTimeout
+    share = split_amount(pool, len(committee))
 
-    # ALL non-leader validators get validatorsTimeout + bond share (no penalties)
-    for addr in validator_addresses:
+    for addr in committee:
         events.append(
             FeeEvent(
                 sequence_id=event_sequence.next_id(),
@@ -88,7 +94,7 @@ def apply_equal_split(
                 hash="0xdefault",
                 cost=0,
                 staked=0,
-                earned=budget.validatorsTimeout + bond_share,
+                earned=share,
                 slashed=0,
                 burned=0,
             )

--- a/tests/fee_distributions/simple_round_types_tests/test_appeal_leader_unsuccessful.py
+++ b/tests/fee_distributions/simple_round_types_tests/test_appeal_leader_unsuccessful.py
@@ -139,28 +139,28 @@ def test_appeal_leader_unsuccessful(verbose, debug):
     ), f"First leader should earn leaderTimeout ({leaderTimeout}) + validatorsTimeout ({validatorsTimeout})"
 
     # First Validator Fees Assert (Round 1: NORMAL_ROUND + Round 3: EQUAL_SPLIT)
-    # In EQUAL_SPLIT (contract semantics), all non-leader validators earn
-    # validatorsTimeout + an equal share of the failed appeal bond
-    bond_share = appeal_bond // 10  # 10 non-leader validators in round 3
+    # In EQUAL_SPLIT (contract semantics), bond + round budget are split
+    # equally across ALL 11 committee members, leader included:
+    # (2300 + 11*200) // 11 = 409, 1 wei dust back to the sender.
+    committee_size = 11
+    share = (appeal_bond + committee_size * validatorsTimeout) // committee_size
     assert all(
         compute_total_earnings(fee_events, addresses_pool[i])
-        == validatorsTimeout + validatorsTimeout + bond_share  # round1 + round3
+        == validatorsTimeout + share  # round1 + round3
         for i in [1, 2, 3, 4]
-    ), f"First validators should earn 2*validatorsTimeout + bond share ({2*validatorsTimeout + bond_share})"
+    ), f"First validators should earn validatorsTimeout + committee share ({validatorsTimeout + share})"
 
     # Second Leader Fees Assert (Round 3: EQUAL_SPLIT)
-    # Leader gets leaderTimeout only (excluded from the validator pool,
-    # contract skipLeader=true)
+    # Leader earns the leader fee plus its validator share of the pool
     assert (
-        compute_total_earnings(fee_events, addresses_pool[5]) == leaderTimeout
-    ), f"Second leader should earn leaderTimeout ({leaderTimeout})"
+        compute_total_earnings(fee_events, addresses_pool[5]) == leaderTimeout + share
+    ), f"Second leader should earn leaderTimeout + committee share ({leaderTimeout + share})"
 
     # Second Validator Fees Assert (Round 3: EQUAL_SPLIT only)
     assert all(
-        compute_total_earnings(fee_events, addresses_pool[i])
-        == validatorsTimeout + bond_share
+        compute_total_earnings(fee_events, addresses_pool[i]) == share
         for i in [6, 7, 8, 9, 10, 11]
-    ), f"Second validators should earn validatorsTimeout + bond share ({validatorsTimeout + bond_share})"
+    ), f"Second validators should earn the committee share ({share})"
 
     # Sender Fees Assert
     total_cost = compute_total_cost(transaction_budget)


### PR DESCRIPTION
## Context

Fifth parity PR, stacked on #23 (chain: #21 → #22 → #23 → #24). The CON-611 `LeaderAppealUnsuccessful` strict pass (genlayer-consensus `bef42d9f`) found one new simulator divergence: the vector's `EQUAL_SPLIT` after a failed leader appeal **excluded the re-execution leader** from the split (430 × 10), but the contract divides bond + round budget across **all 11 committee members** (409 each, 1 wei dust to the sender) plus the leader fee. The simulator was internally inconsistent on this — its own round-0 undetermined treatment *does* pay the leader's validator share. Spec: [CON-611](https://linear.app/genlayer-labs/issue/CON-611) comment.

## The fix

`apply_equal_split` now builds a single pool = previous appeal bond + `committee_size × validatorsTimeout` and pays `pool // committee_size` to **every** committee member, leader included. The leader keeps its separate `leaderTimeout` fee, and the division remainder flows back to the sender through the pot residue — no special-casing needed for the dust.

For the canonical `UNDETERMINED → LEADER_APPEAL_UNSUCCESSFUL → UNDETERMINED` chain (bond 2,300 + budget 2,200 = pool 4,500 over 11): validators 409 each, leader 509 (409 + 100 fee), 1 wei dust — matching the measured contract ledgers exactly.

`test_appeal_leader_unsuccessful` updated from the exclusion semantics to the all-members split.

## Validation

- Simulator suite: **994 passed, 5 skipped**.
- Regenerated vectors (`--max-length 7 --max-rotations 2 --existing-dir`) fed to `con-609-integration-base` (on `bef42d9f`): full `fee_finalization_tests` **222/222**. The regenerated `EQUAL_SPLIT` vectors now carry the 409-per-member composition directly, so the in-code divergence note can be dropped once the vectors are committed.

## Follow-up (consensus repo)

Commit the regenerated vectors and drop the `EQUAL_SPLIT` divergence note in `LeaderAppealUnsuccessful`. Tracked under CON-611.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FeEwcpMkc6yQLzqSaVCAV5