### PR TITLE
land: parity fixes from #22/#23/#24 (stack merge landed on wrong bases)

### DIFF
--- a/src/fee_simulator/core/path_to_transaction.py
+++ b/src/fee_simulator/core/path_to_transaction.py
@@ -258,16 +258,15 @@ def create_appeal_votes(
                     votes[addresses[offset + i]] = "DISAGREE"
                 for i in range(majority_count, size):
                     votes[addresses[offset + i]] = "AGREE"
-            else:  # TIMEOUT or UNDETERMINED
-                # For unsuccessful validator appeal after undetermined, maintain undetermined
-                # Create equal split to ensure no clear majority
-                third = size // 3
-                for i in range(third):
-                    votes[addresses[offset + i]] = "AGREE"
-                for i in range(third, 2 * third):
-                    votes[addresses[offset + i]] = "DISAGREE"
-                for i in range(2 * third, size):
+            else:  # TIMEOUT
+                # On-chain (Rounds.sol) an appeal against ValidatorsTimeout
+                # fails only when the appeal round CONFIRMS the outcome with
+                # a timeout majority; a NoMajority composition would make the
+                # appeal succeed. Synthesize a genuine confirming majority.
+                for i in range(majority_count):
                     votes[addresses[offset + i]] = "TIMEOUT"
+                for i in range(majority_count, size):
+                    votes[addresses[offset + i]] = "AGREE"
 
     return votes
 

--- a/src/fee_simulator/core/refunds.py
+++ b/src/fee_simulator/core/refunds.py
@@ -32,6 +32,18 @@ def compute_sender_refund(
     Note: `burned` on VALIDATOR events is a stake-level penalty, not a fee
     pot flow, so it does not participate here. Only APPEALANT burns (bond
     value the simulator destroys on fallback paths) reduce the pot.
+
+    Contrast with the contracts (FeesProcessor): on-chain the refund bucket
+    (feesToReturnToUser) is ACCRUED flow-by-flow — skip-round fees, bond
+    residues, leader-fee halves, and penalties recorded with
+    returnToUser=true are each credited explicitly. The simulator reaches
+    the same economics implicitly: a penalized validator simply never earns
+    its fee allocation, so that money stays in the pot and lands in this
+    residue-based refund. Any constant delta between this refund and the
+    contract's bucket therefore points to an accrual the contract retains
+    or redistributes (returnToUser=false paths, dust) rather than to a
+    penalty flowing to the sender here — validator penalty burns never
+    enter this refund.
     """
     # TODO: when introducing toppers, we need to change this function
 

--- a/src/fee_simulator/core/round_fee_distribution/equal_split.py
+++ b/src/fee_simulator/core/round_fee_distribution/equal_split.py
@@ -26,12 +26,16 @@ def apply_equal_split(
     - Previous round was APPEAL_LEADER_UNSUCCESSFUL
     - Current round has UNDETERMINED majority
 
-    Fee distribution (contract: _distributeFeesToValidators with
-    skipLeader=true, distributeToAll=true, extra=previousAppealBond):
-    - Leader: earns leaderTimeout only (excluded from the validator pool)
-    - ALL non-leader validators: earn validatorsTimeout + an equal share of
-      the previous appeal bond (no penalties)
+    Fee distribution (contract: bond + round budget divided across ALL
+    committee members, leader included, plus the leader fee — measured on
+    the driven flows, CON-611):
+    - Pool = previous appeal bond + committee_size * validatorsTimeout
+    - EVERY committee member (leader included) earns pool // committee_size
+      as its validator share (no penalties) — same as the round-0
+      undetermined treatment, which also pays the leader's validator share
+    - Leader additionally earns leaderTimeout
     - The bond is NOT returned to the sender; the division remainder is
+      (1 wei dust on an 11-member split)
     """
     events = []
     round_obj = transaction_results.rounds[round_index]
@@ -72,11 +76,13 @@ def apply_equal_split(
             appeal_round_index=round_index - 1,
         )
 
-    validator_addresses = [addr for addr in votes if addr != first_addr]
-    bond_share = split_amount(appeal_bond, len(validator_addresses))
+    # Bond + full round budget split equally across ALL committee members,
+    # leader included; the division remainder flows back to the sender.
+    committee = list(votes.keys())
+    pool = appeal_bond + len(committee) * budget.validatorsTimeout
+    share = split_amount(pool, len(committee))
 
-    # ALL non-leader validators get validatorsTimeout + bond share (no penalties)
-    for addr in validator_addresses:
+    for addr in committee:
         events.append(
             FeeEvent(
                 sequence_id=event_sequence.next_id(),
@@ -88,7 +94,7 @@ def apply_equal_split(
                 hash="0xdefault",
                 cost=0,
                 staked=0,
-                earned=budget.validatorsTimeout + bond_share,
+                earned=share,
                 slashed=0,
                 burned=0,
             )

--- a/src/fee_simulator/core/round_labeling.py
+++ b/src/fee_simulator/core/round_labeling.py
@@ -178,8 +178,11 @@ def classify_vote_appeal(
 
     # Validator appeal: previous round had a clear majority
     else:
-        # Successful if validators changed the outcome
-        if appeal_majority != prev_majority and appeal_majority != "UNDETERMINED":
+        # On-chain (Rounds.sol) an appeal fails only when the appeal round
+        # CONFIRMS the original outcome with a matching majority. A
+        # NoMajority appeal round confirms nothing — the appeal succeeds and
+        # the transaction goes back for re-execution.
+        if appeal_majority != prev_majority:
             return "APPEAL_VALIDATOR_SUCCESSFUL"
         else:
             return "APPEAL_VALIDATOR_UNSUCCESSFUL"

--- a/src/fee_simulator/core/round_labeling.py
+++ b/src/fee_simulator/core/round_labeling.py
@@ -248,10 +248,11 @@ SPECIAL_CASE_PATTERNS = [
         "pattern": [
             "NORMAL_ROUND",
             ["APPEAL_LEADER_SUCCESSFUL", "APPEAL_VALIDATOR_SUCCESSFUL"],
-            # The re-execution may itself be colored LeaderTimeout when it
-            # ends in a validators-timeout majority; the original round is
-            # skipped either way.
-            ["NORMAL_ROUND", "LEADER_TIMEOUT_50_PERCENT"],
+            # The contract retro-skips the appealed round on a successful
+            # appeal regardless of how the re-execution ends
+            # (FeesRecorder): a normal outcome, a validators-timeout
+            # majority colored LeaderTimeout, or a genuine leader timeout.
+            ["NORMAL_ROUND", "LEADER_TIMEOUT_50_PERCENT", "LEADER_TIMEOUT"],
         ],
         "changes": {0: "SKIP_ROUND"},
     },

--- a/tests/fee_distributions/simple_round_types_tests/test_appeal_leader_unsuccessful.py
+++ b/tests/fee_distributions/simple_round_types_tests/test_appeal_leader_unsuccessful.py
@@ -139,28 +139,28 @@ def test_appeal_leader_unsuccessful(verbose, debug):
     ), f"First leader should earn leaderTimeout ({leaderTimeout}) + validatorsTimeout ({validatorsTimeout})"
 
     # First Validator Fees Assert (Round 1: NORMAL_ROUND + Round 3: EQUAL_SPLIT)
-    # In EQUAL_SPLIT (contract semantics), all non-leader validators earn
-    # validatorsTimeout + an equal share of the failed appeal bond
-    bond_share = appeal_bond // 10  # 10 non-leader validators in round 3
+    # In EQUAL_SPLIT (contract semantics), bond + round budget are split
+    # equally across ALL 11 committee members, leader included:
+    # (2300 + 11*200) // 11 = 409, 1 wei dust back to the sender.
+    committee_size = 11
+    share = (appeal_bond + committee_size * validatorsTimeout) // committee_size
     assert all(
         compute_total_earnings(fee_events, addresses_pool[i])
-        == validatorsTimeout + validatorsTimeout + bond_share  # round1 + round3
+        == validatorsTimeout + share  # round1 + round3
         for i in [1, 2, 3, 4]
-    ), f"First validators should earn 2*validatorsTimeout + bond share ({2*validatorsTimeout + bond_share})"
+    ), f"First validators should earn validatorsTimeout + committee share ({validatorsTimeout + share})"
 
     # Second Leader Fees Assert (Round 3: EQUAL_SPLIT)
-    # Leader gets leaderTimeout only (excluded from the validator pool,
-    # contract skipLeader=true)
+    # Leader earns the leader fee plus its validator share of the pool
     assert (
-        compute_total_earnings(fee_events, addresses_pool[5]) == leaderTimeout
-    ), f"Second leader should earn leaderTimeout ({leaderTimeout})"
+        compute_total_earnings(fee_events, addresses_pool[5]) == leaderTimeout + share
+    ), f"Second leader should earn leaderTimeout + committee share ({leaderTimeout + share})"
 
     # Second Validator Fees Assert (Round 3: EQUAL_SPLIT only)
     assert all(
-        compute_total_earnings(fee_events, addresses_pool[i])
-        == validatorsTimeout + bond_share
+        compute_total_earnings(fee_events, addresses_pool[i]) == share
         for i in [6, 7, 8, 9, 10, 11]
-    ), f"Second validators should earn validatorsTimeout + bond share ({validatorsTimeout + bond_share})"
+    ), f"Second validators should earn the committee share ({share})"
 
     # Sender Fees Assert
     total_cost = compute_total_cost(transaction_budget)

--- a/tests/round_labeling/test_chained_unsuccessful_appeals.py
+++ b/tests/round_labeling/test_chained_unsuccessful_appeals.py
@@ -81,7 +81,10 @@ class TestChainedUnsuccessfulAppeals:
                         )
                     ]
                 ),
-                # Round 3: Second appeal (validators still agree - unsuccessful)
+                # Round 3: Second appeal (validators still agree - unsuccessful).
+                # An appeal is unsuccessful only when it CONFIRMS the original
+                # outcome with a matching majority (4/6 AGREE here); a
+                # NoMajority composition would make the appeal succeed.
                 Round(
                     rotations=[
                         Rotation(
@@ -89,9 +92,9 @@ class TestChainedUnsuccessfulAppeals:
                                 addresses_pool[13]: "AGREE",
                                 addresses_pool[14]: "AGREE",
                                 addresses_pool[15]: "AGREE",
-                                addresses_pool[16]: "DISAGREE",
+                                addresses_pool[16]: "AGREE",
                                 addresses_pool[17]: "DISAGREE",
-                                addresses_pool[18]: "TIMEOUT",
+                                addresses_pool[18]: "DISAGREE",
                             }
                         )
                     ]


### PR DESCRIPTION
## What happened

#21–#24 were a stacked chain. #21 merged into `main` correctly, but #22, #23 and #24 were merged before their bases were retargeted, so each landed on the branch below it instead of `main`:

- #22 (`fbdcac3` — NoMajority appeals succeed + confirming timeout majority, CON-610) merged into #21's branch
- #23 (`e5849c0` — retro-skip round 0 on leader-timeout re-executions, CON-610) merged into #22's branch
- #24 (`d1e2669` — include the leader in the EQUAL_SPLIT pool, CON-611) merged into #23's branch

This PR is the tip of that chain (all three commits, already reviewed in their own PRs) targeted at `main`. The diff vs `main` is exactly the #22+#23+#24 content — nothing new.

## Validation

All three fixes were validated at their own PR time (simulator suite 994 passed each; consensus `fee_finalization_tests` 222/222 against the then-current `con-609-integration-base`). A fresh suite run + vector regeneration from merged `main` will follow this merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FeEwcpMkc6yQLzqSaVCAV5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated appeal outcomes to resolve a timeout-related edge case, so validator appeals now produce a clear majority result instead of an undetermined one.
  * Corrected fee distribution for equal-split rounds to include the full committee, which changes how rewards are shared in appeal scenarios.
  * Broadened round labeling so additional skip-round cases are recognized consistently.

* **Documentation**
  * Clarified refund behavior and how simulated refunds differ from on-chain fee flow.

* **Tests**
  * Updated affected tests to reflect the revised appeal and fee-sharing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->