### PR TITLE
fix: leader-timeout appeals draw no committee and do not bump the size tier (CON-612)

### DIFF
--- a/src/fee_simulator/core/path_to_transaction.py
+++ b/src/fee_simulator/core/path_to_transaction.py
@@ -359,6 +359,10 @@ def path_to_transaction_results(
     previous_leaders = []
     normal_count = 0
     appeal_count = 0
+    # Appeals that actually expand the committee (leader/validator vote
+    # appeals). Leader-timeout appeals draw no committee on-chain and do not
+    # advance the size schedule, so they are excluded from this counter.
+    expanding_appeal_count = 0
 
     # For tracking majorities
     prev_majority = None
@@ -380,23 +384,39 @@ def path_to_transaction_results(
                 and "UNSUCCESSFUL" in previous_node
             )
 
-            # Calculate appeal size
-            base_size = (
-                APPEAL_ROUND_SIZES[appeal_count]
-                if appeal_count < len(APPEAL_ROUND_SIZES)
-                else APPEAL_ROUND_SIZES[-1]
-            )
-            required_size = base_size - 2 if prev_was_unsuccessful else base_size
+            is_timeout_appeal = "LEADER_APPEAL_TIMEOUT" in node
 
-            # Pull new addresses for appeal
-            appeal_addresses = []
-            while len(appeal_addresses) < required_size and next_unused_idx < len(
-                addresses
-            ):
-                addr = addresses[next_unused_idx]
-                next_unused_idx += 1
-                if addr not in removed_addresses:
-                    appeal_addresses.append(addr)
+            if is_timeout_appeal:
+                # On-chain a leader-timeout appeal has NO voting committee —
+                # it just replaces the leader and re-executes
+                # (RoundsCreation.createNewLeaderTimeoutAppealRound). The
+                # appeal round keeps only the appellant bookkeeping: NA
+                # entries over the appealed round's committee, no fresh
+                # draws, nothing new enters the cumulative active set.
+                appeal_addresses = (
+                    list(rounds[-1].rotations[-1].votes.keys())
+                    if rounds and rounds[-1].rotations
+                    else []
+                )
+            else:
+                # Calculate appeal size (leader-timeout appeals do not
+                # consume a slot in the appeal size schedule)
+                base_size = (
+                    APPEAL_ROUND_SIZES[expanding_appeal_count]
+                    if expanding_appeal_count < len(APPEAL_ROUND_SIZES)
+                    else APPEAL_ROUND_SIZES[-1]
+                )
+                required_size = base_size - 2 if prev_was_unsuccessful else base_size
+
+                # Pull new addresses for appeal
+                appeal_addresses = []
+                while len(appeal_addresses) < required_size and next_unused_idx < len(
+                    addresses
+                ):
+                    addr = addresses[next_unused_idx]
+                    next_unused_idx += 1
+                    if addr not in removed_addresses:
+                        appeal_addresses.append(addr)
 
             # For validator appeals, use the last normal round's majority as context
             context_majority = (
@@ -411,6 +431,8 @@ def path_to_transaction_results(
             # Update state
             cumulative_active.update(appeal_addresses)
             appeal_count += 1
+            if not is_timeout_appeal:
+                expanding_appeal_count += 1
 
         else:  # Normal round
             # Calculate required size based on blockchain index
@@ -418,8 +440,11 @@ def path_to_transaction_results(
             if normal_count == 0:
                 blockchain_idx = 0
             else:
-                # Count how many appeals have occurred
-                blockchain_idx = 2 * appeal_count
+                # Count how many committee-expanding appeals have occurred.
+                # Leader-timeout appeals re-execute with the SAME committee
+                # (rotation-style leader replacement), so they must not bump
+                # the size tier.
+                blockchain_idx = 2 * expanding_appeal_count
 
             size_idx = blockchain_idx // 2
             required_size = (

--- a/tests/round_combinations/test_address_allocation.py
+++ b/tests/round_combinations/test_address_allocation.py
@@ -376,13 +376,21 @@ class TestAddressAllocation:
             # All should create valid rounds
             assert len(result.rounds) == len(path) - 2
 
-            # Appeals should use new addresses
             if len(result.rounds) > 1:
                 round0_indices = set(self.get_round_indices(result.rounds[0]))
                 round1_indices = set(self.get_round_indices(result.rounds[1]))
-                assert (
-                    len(round0_indices & round1_indices) == 0
-                ), f"Appeal reuses addresses for path {path}"
+                if "LEADER_APPEAL_TIMEOUT" in path[2]:
+                    # Leader-timeout appeals have NO voting committee
+                    # on-chain — the appeal round keeps the appealed round's
+                    # committee as NA bookkeeping and draws nothing new
+                    assert (
+                        round1_indices == round0_indices
+                    ), f"LT appeal should not draw new addresses for path {path}"
+                else:
+                    # Vote appeals draw an entirely new committee
+                    assert (
+                        len(round0_indices & round1_indices) == 0
+                    ), f"Appeal reuses addresses for path {path}"
 
     def test_blockchain_index_calculation(self):
         """Test: Verify blockchain index calculation affects round sizes correctly"""


### PR DESCRIPTION
## Context

Sixth parity PR (based directly on `main` — the previous stack is fully landed). The CON-612 strict pass measured the contract re-executing with the **same 5-member committee** after a successful leader-timeout appeal, while the vectors gave the re-execution an 11-member committee (6 rewarded / 5 penalized). The simulator's own budget already priced the 5-member round — bond 1,100 = 100 + 5×200, appellant reward 1,650 = 1.5×1,100, both matching the contract — only the committee construction diverged.

## Root cause — two compounding effects in `path_to_transaction_results`

1. **The LT-appeal node drew a 7-member appeal committee it shouldn't have**: the appeal branch pulled `APPEAL_ROUND_SIZES[appeal_count]` fresh addresses for every appeal node, including `LEADER_APPEAL_TIMEOUT_*`. On-chain a leader-timeout appeal has **no voting committee** (`RoundsCreation.createNewLeaderTimeoutAppealRound`) — it just replaces the leader and re-executes. The 7 drawn addresses still entered `cumulative_active`.
2. **The re-execution sizing counted the LT appeal as a tier bump** (`blockchain_idx = 2 × appeal_count`), moving the next normal round from tier 0 (5) to tier 1 (11); the membership pull from `cumulative_active` (5 original + 7 appeal − previous leader) supplied exactly those 11.

## The fix (scoped to `LEADER_APPEAL_TIMEOUT_*` nodes only)

- LT appeal rounds **draw no committee addresses** — they keep NA bookkeeping over the appealed round's committee (labeling and the appellant-only payout are unchanged), and nothing enters `cumulative_active`.
- A separate **`expanding_appeal_count`** (excluding LT appeals) now indexes both `NORMAL_ROUND_SIZES` and `APPEAL_ROUND_SIZES`. The re-execution reuses the original round's 5 members minus the timed-out leader plus one replacement — the contract's rotation-style replacement.
- **Plain leader appeals are untouched**: `LEADER_APPEAL_SUCCESSFUL/UNSUCCESSFUL` genuinely expand to 11 on-chain (verified in CON-611: bond 2,300 = 100 + 11×200). The asymmetry is real and bond pricing on both sides already reflects it.

## Post-fix shapes (contract ground truths measured on `1f5e1522`)

- `… → LEADER_RECEIPT_MAJORITY_AGREE`: rewards = {150 LEADER, 200×3 (leader's share + 2 aligned)}, penalties = {200×2}, appellant 1,650; committees 5/5/5. ✔ regenerated vector matches.
- `… → LEADER_RECEIPT_UNDETERMINED`: 5×200 + 150 leader fee, no penalties. ✔ regenerated vector matches.
- Unsuccessful chains keep their (already converged) leader-fee-only shapes; everything regenerated anyway since the sizing touches any chain where a normal round follows an LT appeal, including both `*_rotations` files.

`test_all_appeal_types` updated: LT appeal paths now assert committee reuse instead of fresh draws.

## Validation

- Simulator suite: **994 passed, 5 skipped**.
- Regenerated vectors (`--max-length 7 --max-rotations 2 --existing-dir`) fed to `con-609-integration-base` (on `1f5e1522`): full `fee_finalization_tests` **222/222**. The `LeaderTimeoutAppealSuccessful` strict test's divergence note can be dropped — the vectors now encode the 5-member membership directly.

## Follow-up (consensus repo)

Commit the regenerated vectors (all four `leader_timeout_appeal_*` files plus the sizing-touched chains) and drop the divergence note. Tracked under CON-612.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FeEwcpMkc6yQLzqSaVCAV5