### PR TITLE
fix: leader-timeout appeals re-execute with the N-1 remaining committee (CON-641)

### DIFF
--- a/docs/ADDRESS_ALLOCATION_ALGORITHM.md
+++ b/docs/ADDRESS_ALLOCATION_ALGORITHM.md
@@ -70,6 +70,35 @@ Appeal round sizes are determined by the previous round:
 - Addresses: Pull entirely NEW addresses that haven't been used yet
 - This creates a "shrinking" effect for consecutive unsuccessful appeals
 
+### 3. Leader-Timeout Appeals (Exception: No Committee Draw)
+
+Leader-timeout appeals (`LEADER_APPEAL_TIMEOUT_SUCCESSFUL/UNSUCCESSFUL`) do NOT follow
+the rules above. On-chain (`RoundsCreation.createNewLeaderTimeoutAppealRound`, spec
+03-consensus-stages / 07-appeals-and-rotations):
+
+- The appeal round has **no voting committee**. The simulator keeps NA bookkeeping over
+  the appealed round's committee; nothing new is drawn and nothing enters the cumulative
+  active set. Leader-timeout appeals do not consume a slot in the appeal size schedule
+  and do not bump the normal-round size tier.
+- The **induced re-execution round** (round + 2 on-chain) keeps the SAME validator set
+  with the timed-out leader removed, order preserved — size N-1, **no new validators
+  added**. The new leader is the validator at index `L % (N-1)` of the reduced array
+  (the validator that followed the timed-out leader; wraps to the first element when the
+  timed-out leader held the last index).
+- **Chained timeout appeals shrink the committee each time** (5 → 4 → 3 → 2). Appealing
+  a timed-out round with ≤ 1 member is impossible: the chain reverts `CanNotAppeal`, and
+  `path_to_transaction_results` raises `ValueError` for such paths.
+- The appeal **bond quote is unchanged**: it still prices from the round-size table at
+  the appealed round's index (e.g. `1 × (100 + 5 × 200) = 1100` for a standard round 0),
+  not from the actual N-1 committee. The surplus flows back to the sender through the
+  normal unused-fee remainder.
+
+```
+Round 0 (LEADER_TIMEOUT, size 5):   [0*, 1, 2, 3, 4]     * = timed-out leader
+Round 1 (LT appeal, bookkeeping):   [0, 1, 2, 3, 4]      all NA, nothing drawn
+Round 2 (induced re-execution):     [1*, 2, 3, 4]        * = new leader (L % (N-1))
+```
+
 ### The `-2` Rule: A Mechanical Brake on Escalation
 
 The `-2` rule acts as a **mechanical brake** to prevent security levels from escalating uncontrollably after chains of unsuccessful appeals.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -495,6 +495,7 @@ The system uses a sophisticated address allocation algorithm that determines whi
 2. **Appeal Rounds**: Always pull entirely new addresses that haven't been used yet
 3. **Leader Rotation**: Previous normal round leaders are excluded from future normal rounds
 4. **Deterministic Selection**: The algorithm is fully deterministic given the same path
+5. **Leader-Timeout Appeals (exception)**: Draw no committee at all; the induced re-execution round keeps the same validator set minus the timed-out leader (size N-1, no new validators), and chained timeout appeals shrink the committee each time — see the dedicated section in [ADDRESS_ALLOCATION_ALGORITHM.md](./ADDRESS_ALLOCATION_ALGORITHM.md)
 
 For full details including edge cases, pseudocode, and examples, see [ADDRESS_ALLOCATION_ALGORITHM.md](./ADDRESS_ALLOCATION_ALGORITHM.md)
 

--- a/src/fee_simulator/core/path_to_transaction.py
+++ b/src/fee_simulator/core/path_to_transaction.py
@@ -398,6 +398,16 @@ def path_to_transaction_results(
                     if rounds and rounds[-1].rotations
                     else []
                 )
+                # RoundsCreation reverts CanNotAppeal when the timed-out
+                # round has <= 1 member: dropping the leader would leave an
+                # empty committee for the induced round.
+                if len(appeal_addresses) <= 1:
+                    raise ValueError(
+                        f"CanNotAppeal: leader-timeout appeal at path node {i + 1} "
+                        f"targets a round with {len(appeal_addresses)} member(s); "
+                        "on-chain the appeal reverts once the committee cannot "
+                        "shrink further (RoundsCreation.createNewLeaderTimeoutAppealRound)"
+                    )
             else:
                 # Calculate appeal size (leader-timeout appeals do not
                 # consume a slot in the appeal size schedule)
@@ -435,15 +445,20 @@ def path_to_transaction_results(
                 expanding_appeal_count += 1
 
         else:  # Normal round
+            previous_node = path[i] if i > 0 else None
+            induced_by_timeout_appeal = (
+                previous_node is not None and "LEADER_APPEAL_TIMEOUT" in previous_node
+            )
+
             # Calculate required size based on blockchain index
             # After N appeals, the next normal round is at blockchain index 2*N
             if normal_count == 0:
                 blockchain_idx = 0
             else:
                 # Count how many committee-expanding appeals have occurred.
-                # Leader-timeout appeals re-execute with the SAME committee
-                # (rotation-style leader replacement), so they must not bump
-                # the size tier.
+                # Leader-timeout appeals re-execute with the SAME validator
+                # set minus the timed-out leader, so they must not bump the
+                # size tier.
                 blockchain_idx = 2 * expanding_appeal_count
 
             size_idx = blockchain_idx // 2
@@ -453,7 +468,27 @@ def path_to_transaction_results(
                 else NORMAL_ROUND_SIZES[-1]
             )
 
-            if normal_count == 0:
+            if induced_by_timeout_appeal:
+                # Round induced by a leader-timeout appeal (round + 2
+                # on-chain, RoundsCreation.createNewLeaderTimeoutAppealRound):
+                # the SAME validator set is kept, the timed-out leader is
+                # dropped (order preserved) and the validator at index
+                # L % (N-1) of the reduced array becomes the new leader —
+                # NO new validators are selected. Chained timeout appeals
+                # therefore shrink the committee each time (5 -> 4 -> 3 ...).
+                timed_out_committee = list(
+                    rounds[-2].rotations[-1].votes.keys()
+                )
+                leader_idx = 0  # the simulator always seats the leader first
+                reduced = (
+                    timed_out_committee[:leader_idx]
+                    + timed_out_committee[leader_idx + 1 :]
+                )
+                new_leader_idx = leader_idx % len(reduced)
+                # Rotate so the new leader sits at index 0 (the simulator's
+                # leader slot) while preserving the on-chain array order.
+                normal_addresses = reduced[new_leader_idx:] + reduced[:new_leader_idx]
+            elif normal_count == 0:
                 # First normal round: pull addresses from start
                 normal_addresses = []
                 while len(normal_addresses) < required_size and next_unused_idx < len(

--- a/src/fee_simulator/specification/invariants/definitions/appeal_bond_consistency.py
+++ b/src/fee_simulator/specification/invariants/definitions/appeal_bond_consistency.py
@@ -17,7 +17,9 @@ def check_appeal_bond_consistency(
     Additional invariant: Appeal bonds should be calculated correctly based on
     the new APPEAL_ROUND_SIZES structure.
     """
-    appeal_count = 0
+    # Committee-expanding appeals only: leader-timeout appeals do not
+    # consume a slot in the appeal size schedule.
+    expanding_appeal_count = 0
     for i, label in enumerate(round_labels):
         if is_appeal_round(label):
             # Find the appealant cost event
@@ -27,25 +29,54 @@ def check_appeal_bond_consistency(
                 if e.round_index == i and e.role == "APPEALANT" and e.cost
             ]
 
+            is_timeout_appeal = label.startswith("APPEAL_LEADER_TIMEOUT")
+
             if appealant_events:
                 actual_bond = appealant_events[0].cost
 
-                # Get expected size using the appeal count
-                expected_size = (
-                    APPEAL_ROUND_SIZES[appeal_count]
-                    if appeal_count < len(APPEAL_ROUND_SIZES)
-                    else APPEAL_ROUND_SIZES[-1]
-                )
-                expected_bond = (
-                    expected_size * transaction_budget.validatorsTimeout
-                    + transaction_budget.leaderTimeout
-                )
+                if is_timeout_appeal:
+                    # Leader-timeout appeal: the bond is quoted from the
+                    # round-size table at the appealed round's index, not
+                    # from the appeal size schedule
+                    # (FeeManagerHelpers._leaderTimeoutAppealBond); mirror
+                    # the canonical formula.
+                    from src.fee_simulator.core.bond_computing import (
+                        compute_appeal_bond,
+                    )
+                    from src.fee_simulator.utils_round_sizes import (
+                        find_previous_normal_round,
+                    )
+
+                    normal_round_index = find_previous_normal_round(i, round_labels)
+                    if normal_round_index is None:
+                        normal_round_index = i - 1
+                    expected_bond = compute_appeal_bond(
+                        normal_round_index=normal_round_index,
+                        leader_timeout=transaction_budget.leaderTimeout,
+                        validators_timeout=transaction_budget.validatorsTimeout,
+                        round_labels=round_labels,
+                        appeal_round_index=i,
+                        rotations=transaction_budget.rotations,
+                    )
+                    expected_size = None
+                else:
+                    # Get expected size using the committee-expanding appeal count
+                    expected_size = (
+                        APPEAL_ROUND_SIZES[expanding_appeal_count]
+                        if expanding_appeal_count < len(APPEAL_ROUND_SIZES)
+                        else APPEAL_ROUND_SIZES[-1]
+                    )
+                    expected_bond = (
+                        expected_size * transaction_budget.validatorsTimeout
+                        + transaction_budget.leaderTimeout
+                    )
 
                 if actual_bond != expected_bond:
                     raise InvariantViolation(
                         "appeal_bond_consistency",
-                        f"Appeal {appeal_count} (round {i}): Expected bond {expected_bond} "
+                        f"Appeal at round {i} ({label}): Expected bond {expected_bond} "
                         f"(size {expected_size}), but got {actual_bond}",
                     )
 
-            appeal_count += 1
+            if not is_timeout_appeal:
+                expanding_appeal_count += 1

--- a/src/fee_simulator/specification/invariants/definitions/appellant_consistency.py
+++ b/src/fee_simulator/specification/invariants/definitions/appellant_consistency.py
@@ -48,26 +48,54 @@ def check_appellant_consistency(
             )
 
     # Verify bond amounts match expected values
-    appeal_count = 0
-    for i, event in enumerate(bond_events):
-        # Find which appeal number this is
+    for event in bond_events:
         round_idx = event.round_index
-        appeal_idx = appeal_rounds.index(round_idx)
+        label = round_labels[round_idx]
 
-        # Calculate expected bond using the appeal count
-        expected_size = (
-            APPEAL_ROUND_SIZES[appeal_idx]
-            if appeal_idx < len(APPEAL_ROUND_SIZES)
-            else APPEAL_ROUND_SIZES[-1]
-        )
-        expected_bond = (
-            expected_size * transaction_budget.validatorsTimeout
-            + transaction_budget.leaderTimeout
-        )
+        if label.startswith("APPEAL_LEADER_TIMEOUT"):
+            # Leader-timeout appeal: the bond is quoted from the round-size
+            # table at the appealed round's index, not from the appeal size
+            # schedule (FeeManagerHelpers._leaderTimeoutAppealBond); mirror
+            # the canonical formula.
+            from src.fee_simulator.core.bond_computing import compute_appeal_bond
+            from src.fee_simulator.utils_round_sizes import (
+                find_previous_normal_round,
+            )
+
+            normal_round_index = find_previous_normal_round(round_idx, round_labels)
+            if normal_round_index is None:
+                normal_round_index = round_idx - 1
+            expected_bond = compute_appeal_bond(
+                normal_round_index=normal_round_index,
+                leader_timeout=transaction_budget.leaderTimeout,
+                validators_timeout=transaction_budget.validatorsTimeout,
+                round_labels=round_labels,
+                appeal_round_index=round_idx,
+                rotations=transaction_budget.rotations,
+            )
+            expected_size = None
+        else:
+            # Committee-expanding appeals only: leader-timeout appeals do
+            # not consume a slot in the appeal size schedule.
+            appeal_idx = sum(
+                1
+                for j in appeal_rounds
+                if j < round_idx
+                and not round_labels[j].startswith("APPEAL_LEADER_TIMEOUT")
+            )
+            expected_size = (
+                APPEAL_ROUND_SIZES[appeal_idx]
+                if appeal_idx < len(APPEAL_ROUND_SIZES)
+                else APPEAL_ROUND_SIZES[-1]
+            )
+            expected_bond = (
+                expected_size * transaction_budget.validatorsTimeout
+                + transaction_budget.leaderTimeout
+            )
 
         if event.cost != expected_bond:
             raise InvariantViolation(
                 "appellant_consistency",
-                f"Appeal {appeal_idx} (round {round_idx}): Bond amount {event.cost} "
+                f"Appeal at round {round_idx} ({label}): Bond amount {event.cost} "
                 f"doesn't match expected {expected_bond} (size {expected_size})",
             )

--- a/src/fee_simulator/specification/invariants/definitions/round_size_consistency.py
+++ b/src/fee_simulator/specification/invariants/definitions/round_size_consistency.py
@@ -18,7 +18,15 @@ def check_round_size_consistency(
     the expected size from NORMAL_ROUND_SIZES or APPEAL_ROUND_SIZES.
     """
     normal_count = 0
-    appeal_count = 0
+    # Committee-expanding appeals only: leader-timeout appeals draw no
+    # committee on-chain and do not consume a slot in the size schedules.
+    expanding_appeal_count = 0
+
+    def _round_participants(round_obj) -> set:
+        participants = set()
+        for rotation in round_obj.rotations:
+            participants.update(rotation.votes.keys())
+        return participants
 
     for i, (round_obj, label) in enumerate(
         zip(transaction_results.rounds, round_labels)
@@ -27,13 +35,19 @@ def check_round_size_consistency(
             continue
         if round_obj.rotations:
             # Count unique participants in this round
-            participants = set()
-            for rotation in round_obj.rotations:
-                participants.update(rotation.votes.keys())
+            actual_size = len(_round_participants(round_obj))
 
-            actual_size = len(participants)
-
-            if is_appeal_round(label):
+            if label in ("APPEAL_LEADER_TIMEOUT_SUCCESSFUL", "APPEAL_LEADER_TIMEOUT_UNSUCCESSFUL"):
+                # Leader-timeout appeals have NO voting committee on-chain
+                # (RoundsCreation.createNewLeaderTimeoutAppealRound); the
+                # simulator keeps NA bookkeeping over the appealed round's
+                # committee, so the sizes must match exactly.
+                expected_size = (
+                    len(_round_participants(transaction_results.rounds[i - 1]))
+                    if i > 0
+                    else actual_size
+                )
+            elif is_appeal_round(label):
                 # Check if previous round was an unsuccessful appeal
                 prev_was_unsuccessful_appeal = (
                     i > 0
@@ -43,8 +57,8 @@ def check_round_size_consistency(
 
                 # Get base size for this appeal
                 base_size = (
-                    APPEAL_ROUND_SIZES[appeal_count]
-                    if appeal_count < len(APPEAL_ROUND_SIZES)
+                    APPEAL_ROUND_SIZES[expanding_appeal_count]
+                    if expanding_appeal_count < len(APPEAL_ROUND_SIZES)
                     else APPEAL_ROUND_SIZES[-1]
                 )
 
@@ -52,15 +66,29 @@ def check_round_size_consistency(
                 expected_size = (
                     base_size - 2 if prev_was_unsuccessful_appeal else base_size
                 )
-                appeal_count += 1
+                expanding_appeal_count += 1
+            elif i > 0 and round_labels[i - 1] in (
+                "APPEAL_LEADER_TIMEOUT_SUCCESSFUL",
+                "APPEAL_LEADER_TIMEOUT_UNSUCCESSFUL",
+            ):
+                # Round induced by a leader-timeout appeal: the appealed
+                # round's committee minus the timed-out leader, no new
+                # validators (5 -> 4 -> 3 on chained timeout appeals).
+                expected_size = max(
+                    len(_round_participants(transaction_results.rounds[i - 1])) - 1, 1
+                )
+                normal_count += 1
             else:
                 # Normal rounds - calculate blockchain index properly
                 if normal_count == 0:
                     blockchain_index = 0
                 else:
-                    # Count appeals before this normal round
+                    # Count committee-expanding appeals before this round
                     appeals_before = sum(
-                        1 for j in range(i) if is_appeal_round(round_labels[j])
+                        1
+                        for j in range(i)
+                        if is_appeal_round(round_labels[j])
+                        and not round_labels[j].startswith("APPEAL_LEADER_TIMEOUT")
                     )
                     blockchain_index = 2 * appeals_before
 

--- a/tests/fee_distributions/simple_round_types_tests/test_leader_timeout_150_previous_normal_round.py
+++ b/tests/fee_distributions/simple_round_types_tests/test_leader_timeout_150_previous_normal_round.py
@@ -41,7 +41,17 @@ transaction_budget = TransactionBudget(
 
 
 def test_leader_timeout_150_previous_normal_round(verbose, debug):
-    """Test leader_timeout_150_previous_normal_round: leader timeout, appeal successful, normal round."""
+    """Test leader_timeout_150_previous_normal_round: leader timeout, appeal successful, normal round.
+
+    Spec semantics (RoundsCreation.createNewLeaderTimeoutAppealRound): the
+    leader-timeout appeal keeps the SAME validator set, drops the timed-out
+    leader, and elects the validator at index L % (N-1) of the reduced array
+    as the new leader — no new validators are added. The appeal round itself
+    has no voting committee; it keeps NA bookkeeping over the appealed
+    round's committee. The induced re-execution round therefore has N-1
+    members (here: leader + 2 agree + 1 disagree on the 4-member remaining
+    committee).
+    """
     # Setup
     rotation1 = Rotation(
         votes={
@@ -53,21 +63,14 @@ def test_leader_timeout_150_previous_normal_round(verbose, debug):
         }
     )
     rotation2 = Rotation(
-        votes={addresses_pool[i]: "NA" for i in [5, 6, 7, 8, 9, 10, 11]}
+        votes={addresses_pool[i]: "NA" for i in [0, 1, 2, 3, 4]}
     )
     rotation3 = Rotation(
         votes={
-            addresses_pool[5]: ["LEADER_RECEIPT", "AGREE"],
+            addresses_pool[1]: ["LEADER_RECEIPT", "AGREE"],
             addresses_pool[2]: "AGREE",
             addresses_pool[3]: "AGREE",
-            addresses_pool[4]: "AGREE",
-            addresses_pool[1]: "AGREE",
-            addresses_pool[6]: "AGREE",
-            addresses_pool[7]: "DISAGREE",
-            addresses_pool[8]: "DISAGREE",
-            addresses_pool[9]: "DISAGREE",
-            addresses_pool[10]: "TIMEOUT",
-            addresses_pool[11]: "TIMEOUT",
+            addresses_pool[4]: "DISAGREE",
         }
     )
     transaction_results = TransactionRoundResults(
@@ -115,16 +118,19 @@ def test_leader_timeout_150_previous_normal_round(verbose, debug):
     assert all(
         compute_all_zeros(fee_events, addresses_pool[i])
         for i in range(len(addresses_pool))
-        if i not in [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 23, 1999]
+        if i not in [0, 1, 2, 3, 4, 23, 1999]
     ), "Everyone else should have no fees"
 
-    # Appealant Fees Assert
+    # Appealant Fees Assert (bond still quoted from the round-size table at
+    # the appealed round's index — 1 x (100 + 5 x 200) = 1100 — even though
+    # the induced round seats one fewer body)
     appeal_bond = compute_appeal_bond(
         normal_round_index=0,
         leader_timeout=leaderTimeout,
         validators_timeout=validatorsTimeout,
         round_labels=round_labels,
     )
+    assert appeal_bond == leaderTimeout + 5 * validatorsTimeout
     assert compute_total_earnings(fee_events, addresses_pool[23]) == int(
         appeal_bond * 1.5
     ), f"Appealant should earn 1.5x appeal_bond ({int(appeal_bond * 1.5)}) for 50% return"
@@ -132,28 +138,30 @@ def test_leader_timeout_150_previous_normal_round(verbose, debug):
         compute_total_costs(fee_events, addresses_pool[23]) == appeal_bond
     ), f"Appealant should have cost equal to appeal_bond ({appeal_bond})"
 
-    # First Leader Fees Assert
+    # First Leader Fees Assert (timed-out leader is dropped from the induced
+    # round and earns nothing)
     assert (
         compute_total_earnings(fee_events, addresses_pool[0]) == 0
     ), f"First leader should earn 0"
 
-    # Second Leader Fees Assert
+    # Second Leader Fees Assert (the validator that followed the timed-out
+    # leader in the original order: 150 leader fee + 200 validator share)
     assert (
-        compute_total_earnings(fee_events, addresses_pool[5])
+        compute_total_earnings(fee_events, addresses_pool[1])
         == leaderTimeout * 1.5 + validatorsTimeout
-    ), f"Second leader should earn 150% of leaderTimeout ({leaderTimeout * 1.5})"
+    ), f"Second leader should earn 150% of leaderTimeout plus validator share ({leaderTimeout * 1.5 + validatorsTimeout})"
 
     # Majority Validator Fees Assert
     assert all(
         compute_total_earnings(fee_events, addresses_pool[i]) == validatorsTimeout
-        for i in [1, 2, 3, 4, 6]
+        for i in [2, 3]
     ), f"Majority validators should earn validatorsTimeout ({validatorsTimeout})"
 
     # Minority Validator Fees Assert
     assert all(
         compute_total_burnt(fee_events, addresses_pool[i])
         == PENALTY_REWARD_COEFFICIENT * validatorsTimeout
-        for i in [7, 8, 9, 10, 11]
+        for i in [4]
     ), f"Minority validators should be burned {PENALTY_REWARD_COEFFICIENT * validatorsTimeout}"
 
     # Sender Fees Assert

--- a/tests/fee_distributions/simple_round_types_tests/test_leader_timeout_50_previous_appeal_bond.py
+++ b/tests/fee_distributions/simple_round_types_tests/test_leader_timeout_50_previous_appeal_bond.py
@@ -39,7 +39,15 @@ transaction_budget = TransactionBudget(
 
 
 def test_leader_timeout_50_previous_appeal_bond(verbose, debug):
-    """Test leader_timeout_50_previous_appeal_bond: leader timeout, appeal unsuccessful, leader timeout."""
+    """Test leader_timeout_50_previous_appeal_bond: leader timeout, appeal unsuccessful, leader timeout.
+
+    Spec semantics (RoundsCreation.createNewLeaderTimeoutAppealRound): the
+    leader-timeout appeal keeps the SAME validator set, drops the timed-out
+    leader, and seats the next validator in order as the new leader — no new
+    validators are added. The induced round here times out again (the appeal
+    is unsuccessful), so it is the 4-member remaining committee led by the
+    validator that followed the original leader.
+    """
     # Setup
     rotation1 = Rotation(
         votes={
@@ -51,17 +59,14 @@ def test_leader_timeout_50_previous_appeal_bond(verbose, debug):
         }
     )
     rotation2 = Rotation(
-        votes={addresses_pool[i]: "NA" for i in [5, 6, 7, 8, 9, 10, 11]}
+        votes={addresses_pool[i]: "NA" for i in [0, 1, 2, 3, 4]}
     )
     rotation3 = Rotation(
         votes={
-            addresses_pool[5]: ["LEADER_TIMEOUT", "NA"],
-            addresses_pool[6]: "NA",
-            addresses_pool[7]: "NA",
-            addresses_pool[8]: "NA",
-            addresses_pool[9]: "NA",
-            addresses_pool[10]: "NA",
-            addresses_pool[11]: "NA",
+            addresses_pool[1]: ["LEADER_TIMEOUT", "NA"],
+            addresses_pool[2]: "NA",
+            addresses_pool[3]: "NA",
+            addresses_pool[4]: "NA",
         }
     )
     transaction_results = TransactionRoundResults(
@@ -109,7 +114,7 @@ def test_leader_timeout_50_previous_appeal_bond(verbose, debug):
     assert all(
         compute_all_zeros(fee_events, addresses_pool[i])
         for i in range(len(addresses_pool))
-        if i not in [0, 5, 23, 1999]
+        if i not in [0, 1, 23, 1999]
     ), "Everyone else should have no fees"
 
     # Appealant Fees Assert
@@ -132,9 +137,10 @@ def test_leader_timeout_50_previous_appeal_bond(verbose, debug):
     ), f"First leader should earn 50% of leaderTimeout ({leaderTimeout * 0.5})"
 
     # Second Leader Fees Assert (contract semantics: the failed timeout
-    # appeal bond is split 50/50 between the new leader and the sender)
+    # appeal bond is split 50/50 between the new leader — the validator that
+    # followed the timed-out leader — and the sender)
     assert (
-        compute_total_earnings(fee_events, addresses_pool[5]) == appeal_bond // 2
+        compute_total_earnings(fee_events, addresses_pool[1]) == appeal_bond // 2
     ), f"Second leader should earn half the appeal bond ({appeal_bond // 2})"
 
     # Sender receives the other half of the bond as an explicit credit

--- a/tests/round_combinations/test_address_allocation.py
+++ b/tests/round_combinations/test_address_allocation.py
@@ -392,6 +392,90 @@ class TestAddressAllocation:
                         len(round0_indices & round1_indices) == 0
                     ), f"Appeal reuses addresses for path {path}"
 
+    def test_leader_timeout_appeal_induced_round_keeps_reduced_committee(self):
+        """Test: the round induced by a leader-timeout appeal keeps the SAME
+        validator set minus the timed-out leader, order preserved, with the
+        validator at index L % (N-1) of the reduced array as the new leader —
+        no new validators (RoundsCreation.createNewLeaderTimeoutAppealRound).
+        """
+        for terminal in [
+            "LEADER_RECEIPT_MAJORITY_AGREE",
+            "LEADER_RECEIPT_UNDETERMINED",
+        ]:
+            path = [
+                "START",
+                "LEADER_TIMEOUT",
+                "LEADER_APPEAL_TIMEOUT_SUCCESSFUL",
+                terminal,
+                "END",
+            ]
+            result, _ = path_to_transaction_results(
+                path=path,
+                addresses=self.addresses,
+                sender_address=self.sender_address,
+                appealant_address=self.appealant_address,
+            )
+
+            round0 = list(result.rounds[0].rotations[-1].votes.keys())
+            round2 = list(result.rounds[2].rotations[-1].votes.keys())
+
+            # Timed-out leader (index 0) dropped, order preserved, size N-1,
+            # nothing new drawn
+            assert round2 == round0[1:], (
+                f"Induced round must be the timed-out committee minus its "
+                f"leader for terminal {terminal}"
+            )
+            # New leader = reduced[L % (N-1)] = the validator that followed
+            # the timed-out leader
+            assert self.get_leader_index(result.rounds[2]) == (
+                self.address_to_index[round0[1]]
+            )
+
+    def test_chained_leader_timeout_appeals_shrink_committee(self):
+        """Test: chained timeout appeals shrink the committee at EACH appeal
+        (5 -> 4 -> 3), with the majority denominator following."""
+        path = [
+            "START",
+            "LEADER_TIMEOUT",
+            "LEADER_APPEAL_TIMEOUT_UNSUCCESSFUL",
+            "LEADER_TIMEOUT",
+            "LEADER_APPEAL_TIMEOUT_SUCCESSFUL",
+            "LEADER_RECEIPT_MAJORITY_AGREE",
+            "END",
+        ]
+        result, _ = path_to_transaction_results(
+            path=path,
+            addresses=self.addresses,
+            sender_address=self.sender_address,
+            appealant_address=self.appealant_address,
+        )
+
+        committees = [
+            list(r.rotations[-1].votes.keys()) for r in result.rounds
+        ]
+        assert [len(c) for c in committees] == [5, 5, 4, 4, 3]
+
+        # Each induced round drops the previous timed-out leader only
+        assert committees[2] == committees[0][1:]
+        assert committees[4] == committees[0][2:]
+
+    def test_leader_timeout_appeal_reverts_when_committee_cannot_shrink(self):
+        """Test: appealing a timed-out round with <= 1 member raises, mirroring
+        the on-chain CanNotAppeal revert (RoundsCreation)."""
+        # 5 -> 4 -> 3 -> 2 -> 1; the fifth appeal targets a 1-member round
+        path = (
+            ["START"]
+            + ["LEADER_TIMEOUT", "LEADER_APPEAL_TIMEOUT_UNSUCCESSFUL"] * 5
+            + ["LEADER_TIMEOUT", "END"]
+        )
+        with pytest.raises(ValueError, match="CanNotAppeal"):
+            path_to_transaction_results(
+                path=path,
+                addresses=self.addresses,
+                sender_address=self.sender_address,
+                appealant_address=self.appealant_address,
+            )
+
     def test_blockchain_index_calculation(self):
         """Test: Verify blockchain index calculation affects round sizes correctly"""
         # Path with specific appeal pattern to test blockchain indices


### PR DESCRIPTION
## What

Adopts the spec-correct leader-timeout appeal semantics implemented on-chain in genlayerlabs/genlayer-consensus#1208 (CON-641, `RoundsCreation.createNewLeaderTimeoutAppealRound`):

> For LEADER_TIMEOUT appeals the same validator set is kept, the original leader is removed, and a new leader is elected from the remaining validators (leader rotation, **no new validators added**).

Until now the simulator modeled the induced re-execution round as the original committee minus the timed-out leader **plus one fresh replacement** (the pre-#1208 rotation-style model measured in CON-612). Neither that nor the old v6 vectors (which seated an external `validator6` as the new leader) match the spec.

## Changes

- **`path_to_transaction.py`**: a normal round following a `LEADER_APPEAL_TIMEOUT_*` node reuses the timed-out round's committee minus its leader, order preserved, size N-1; the new leader is `reduced[L % (N-1)]` (the validator that followed the timed-out leader). Nothing is drawn from the pool. Chained timeout appeals shrink the committee at each appeal (5 → 4 → 3), with the majority denominator following. Appealing a timed-out round with ≤ 1 member raises `ValueError`, mirroring the `CanNotAppeal` revert.
- **Invariants** (`round_size_consistency`, `appeal_bond_consistency`, `appellant_consistency`) taught the same semantics: LT appeal rounds are NA bookkeeping over the appealed committee and consume no slot in the appeal size schedule; the induced round is expected at N-1; LT bonds check against the canonical table-priced formula.
- **Tests**: hand-built round-type tests updated to the spec shape (4-member induced round: leader 350 = 150 fee + 200 share, aligned voters 200, one penalized voter 200, appellant 1,650). New address-allocation tests pin the reduced committee, the chained 5 → 4 → 3 shrink, and the `CanNotAppeal` guard.
- **Docs**: dedicated LT-appeal section in `ADDRESS_ALLOCATION_ALGORITHM.md`, pointer in `ARCHITECTURE.md`.

## What does NOT change

Bond quote (still priced from the round-size table at the appealed round's index: 1,100 for a standard round 0; appellant custody 1.5× = 1,650), round typing, and the per-unit type-7 distribution amounts.

## Verification

- Simulator suite: **997 passed, 5 skipped** (3 new tests).
- Regenerated consensus vectors from this branch splice cleanly (only patterns passing through `LEADER_TIMEOUT -> LEADER_APPEAL_TIMEOUT_*` change); consensus `fee_finalization_tests` with the vectors and the `specPenalties` shim removed: **239 passing** — see the companion consensus PR.

CON-641

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GX6TDVEMxLZ3KdACgCKWbg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected leader-timeout appeals to reuse the existing validator set without drawing new validators.
  * Ensured timed-out leaders are removed and chained appeals progressively reduce committee size.
  * Prevented appeals when the resulting committee would be too small.
  * Corrected appeal bond calculations and fee distributions for leader-timeout scenarios.
  * Improved validation of round sizes, participants, and appeal bonds.

* **Documentation**
  * Added detailed guidance explaining leader-timeout appeal behavior and committee changes.

* **Tests**
  * Added coverage for reduced committees, chained appeals, and invalid appeal attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->