### PR TITLE
[handoff] fix: make appeal economics exact across configured rounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ To understand the consensus concepts (voting, appeals, rounds), see [docs/BASIC_
 ## What it does NOT do
 
 - **It does not verify the contracts — it models them.** Parity holds only as long as both sides move together (see *Parity discipline* below). The enforcement point is the vector-driven test suites in `genlayer-consensus`, not this repo.
+- **Settlement vectors start after admission.** They do not run live validator selection, capacity-limited appeal admission, or the public `bond + funding` quote. Those surfaces require quote-equals-submission contract tests and shared Studio/Consensus E2E coverage in addition to vector parity.
 - **It only models the time-unit fee layer.** Out of scope: the unified execution budget (gas/receipt/storage fees), the developer-fee gross-up, the GEN-per-time-unit price multiplier, message fees, and top-ups. Amounts here are raw time-unit fees (e.g. `leaderTimeout=100`, `validatorsTimeout=200`).
 - **It abstracts validator identity.** Committee sizes, roles and vote alignment match the contracts; the concrete address selection (VRF, consumed-validator tracking) does not — compare quantities and roles, never addresses.
 - **Round sizes cap at 1000** for simulation purposes; the on-chain `VALIDATORS_PER_ROUND` continues to 1535/1537.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,7 @@ pytest==7.4.4
 pytest-xdist==3.7.0
 tabulate==0.9.0
 hypothesis==6.132.0
+numpy==2.5.2
+pydantic==2.13.4
+rich==15.0.0
+tqdm==4.70.0

--- a/scripts/13_upgrade_consensus_appeal_economics.py
+++ b/scripts/13_upgrade_consensus_appeal_economics.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Upgrade checked-in consensus vectors without regenerating scenarios."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from src.fee_simulator.analysis.consensus_vector_conformance import (  # noqa: E402
+    upgrade_case_to_current_appeal_economics,
+)
+
+
+ECONOMICS_VERSION = "successful-appeal-5/2-vindication-v1"
+
+
+def summarize(examples: list[dict]) -> dict[str, int]:
+    return {
+        "rewards": sum(
+            int(reward["amount"])
+            for example in examples
+            for reward in example["expectedState"]["rewards"]
+        ),
+        "penalties": sum(
+            int(penalty["amount"])
+            for example in examples
+            for penalty in example["expectedState"]["penalties"]
+        ),
+        "sender_outcomes": sum(
+            int(example["expectedState"]["sender_outcome"]["net_change"])
+            for example in examples
+        ),
+    }
+
+
+def upgrade_file(path: Path, *, write: bool) -> tuple[int, bool]:
+    payload = json.loads(path.read_text())
+    patterns = payload.get("patterns")
+    if not patterns or payload.get("appeal_economics_version") == ECONOMICS_VERSION:
+        return 0, False
+
+    upgraded_cases = 0
+    for pattern, pattern_data in patterns.items():
+        examples = pattern_data.get("examples", [])
+        upgraded = []
+        for example_index, example in enumerate(examples):
+            future = upgrade_case_to_current_appeal_economics(
+                example,
+                source=str(path),
+                pattern=pattern,
+                example_index=example_index,
+            )
+            upgraded.append(future)
+            if future != example:
+                upgraded_cases += 1
+        pattern_data["examples"] = upgraded
+        if "summary" in pattern_data:
+            pattern_data["summary"] = summarize(upgraded)
+
+    if upgraded_cases == 0:
+        return 0, False
+    payload["appeal_economics_version"] = ECONOMICS_VERSION
+    if write:
+        path.write_text(json.dumps(payload, indent="\t") + "\n")
+    return upgraded_cases, True
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("vectors_dir", type=Path)
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help="write the validated upgrades; otherwise report the pending files",
+    )
+    args = parser.parse_args()
+
+    files = 0
+    cases = 0
+    for path in sorted(args.vectors_dir.rglob("*.json")):
+        upgraded_cases, changed = upgrade_file(path, write=args.write)
+        if changed:
+            files += 1
+            cases += upgraded_cases
+            action = "upgraded" if args.write else "would upgrade"
+            print(f"{action}: {path} ({upgraded_cases} cases)")
+    print(f"files={files} cases={cases} write={args.write}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/fee_simulator/analysis/consensus_vector_conformance.py
+++ b/src/fee_simulator/analysis/consensus_vector_conformance.py
@@ -17,6 +17,7 @@ as an independent protocol change.
 from __future__ import annotations
 
 from collections import Counter
+from copy import deepcopy
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Iterable
@@ -358,6 +359,110 @@ def compare_case(
         upfront_reserve_delta=upfront_reserve_delta,
         sender_refund_delta=sender_refund_delta,
     )
+
+
+def upgrade_case_to_current_appeal_economics(
+    legacy: dict[str, Any],
+    *,
+    source: str,
+    pattern: str,
+    example_index: int = 0,
+) -> dict[str, Any]:
+    """Upgrade a legacy consensus vector without regenerating its scenario.
+
+    The historical vector generator uses randomized committees, so a full
+    regeneration obscures a small economics change behind a very large diff.
+    This function preserves the scenario and upgrades only the deltas already
+    accepted by :func:`compare_case`: exact 2.5x successful-appeal custody,
+    clear-majority voter vindication, and the conservation-derived sender
+    outcome after reserving the additional appeal profit.
+    """
+
+    future = deepcopy(legacy)
+    rounds = future["initialState"]["rounds"]
+    state = future["expectedState"]
+    legacy_total_rewards = sum(int(entry["amount"]) for entry in state["rewards"])
+
+    for entry in state["rewards"]:
+        if entry.get("role") != "APPEALANT":
+            continue
+        legacy_return = int(entry["amount"])
+        if legacy_return * 2 % 3:
+            _fail(
+                source,
+                pattern,
+                f"round {entry['round_index']} legacy appellant return cannot "
+                "be inverted as an integral 1.5x bond",
+            )
+        bond = legacy_return * 2 // 3
+        entry["amount"] = str(bond * 5 // 2)
+
+    for appeal_position, round_ in enumerate(rounds):
+        if round_["type"] != "VALIDATOR_APPEAL_SUCCESSFUL":
+            continue
+        majority = _majority(round_.get("validators", []))
+        if majority == "UNDETERMINED":
+            continue
+        original = _previous_original_round(rounds, appeal_position)
+        if original is None:
+            _fail(source, pattern, f"round {appeal_position} has no original round")
+
+        round_index = int(round_["round_index"])
+        validator_rewards = [
+            entry
+            for entry in state["rewards"]
+            if int(entry["round_index"]) == round_index
+            and entry.get("role") == "VALIDATOR"
+        ]
+        amounts = {int(entry["amount"]) for entry in validator_rewards}
+        if len(amounts) != 1:
+            _fail(
+                source,
+                pattern,
+                f"round {round_index} validator rewards are not uniform: "
+                f"{sorted(amounts)}",
+            )
+        validator_reward = next(iter(amounts))
+        existing = {
+            entry["address"]
+            for entry in validator_rewards
+        }
+        for validator in original.get("validators", []):
+            address = validator["address"]
+            if _vote(validator["vote"]) != majority or address in existing:
+                continue
+            state["rewards"].append(
+                {
+                    "address": address,
+                    "amount": str(validator_reward),
+                    "round_index": round_index,
+                    "role": "VALIDATOR",
+                }
+            )
+            existing.add(address)
+
+    future_total_rewards = sum(int(entry["amount"]) for entry in state["rewards"])
+    reward_delta = future_total_rewards - legacy_total_rewards
+    appeal_count = sum(round_["type"] in ALL_APPEAL_TYPES for round_ in rounds)
+    reserve_delta = sum(
+        VECTOR_LEADER_TIMEOUT
+        + NORMAL_ROUND_SIZES[min(appeal_ordinal + 1, len(NORMAL_ROUND_SIZES) - 1)]
+        * VECTOR_VALIDATOR_TIMEOUT
+        for appeal_ordinal in range(appeal_count)
+    )
+    legacy_refund = int(legacy["expectedState"]["sender_outcome"]["net_change"])
+    state["sender_outcome"]["net_change"] = str(
+        legacy_refund + reserve_delta - reward_delta
+    )
+
+    compare_case(
+        legacy,
+        future,
+        source=source,
+        pattern=pattern,
+        example_index=example_index,
+    )
+    return future
 
 
 def _load_pattern_files(directory: Path) -> dict[str, dict[str, Any]]:

--- a/src/fee_simulator/analysis/consensus_vector_conformance.py
+++ b/src/fee_simulator/analysis/consensus_vector_conformance.py
@@ -12,6 +12,13 @@ accepts only the two pending economic changes:
 The sender-refund difference is checked as the conservation consequence of
 the larger upfront reserve and the two payout changes.  It is not classified
 as an independent protocol change.
+
+Scope boundary: these vectors begin with an already-admitted sequence of
+rounds. They certify bond/reward/penalty settlement for that sequence, but do
+not execute live validator selection, appeal-capacity admission, or the public
+``bond + funding`` quote. A Solidity quote can therefore select the wrong jury
+size while every vector here remains green. Quote parity needs the separate
+cross-stack admission scenarios and the Solidity quote-equals-submission tests.
 """
 
 from __future__ import annotations

--- a/src/fee_simulator/core/majority.py
+++ b/src/fee_simulator/core/majority.py
@@ -64,7 +64,13 @@ def compute_majority(
         return "UNDETERMINED"
 
     # Count votes by type
-    vote_counts = {"AGREE": 0, "DISAGREE": 0, "TIMEOUT": 0, "IDLE": 0}
+    vote_counts = {
+        "AGREE": 0,
+        "DISAGREE": 0,
+        "TIMEOUT": 0,
+        "DETERMINISTIC_VIOLATION": 0,
+        "IDLE": 0,
+    }
     for addr, vote in rotation.items():
         vote_type = normalize_vote(vote)
         if vote_type in vote_counts:
@@ -85,6 +91,8 @@ def compute_majority(
         return "DISAGREE"
     elif vote_counts["TIMEOUT"] >= majority_threshold:
         return "TIMEOUT"
+    elif vote_counts["DETERMINISTIC_VIOLATION"] >= majority_threshold:
+        return "DETERMINISTIC_VIOLATION"
     else:
         return "UNDETERMINED"
 

--- a/src/fee_simulator/core/round_fee_distribution/appeal_leader_successful.py
+++ b/src/fee_simulator/core/round_fee_distribution/appeal_leader_successful.py
@@ -1,4 +1,4 @@
-from src.fee_simulator.protocol.constants import APPEAL_REWARD_MULTIPLE
+from src.fee_simulator.protocol.appeal_economics import successful_appeal_reward
 from typing import List
 from src.fee_simulator.protocol.models import (
     TransactionRoundResults,
@@ -58,7 +58,7 @@ def apply_appeal_leader_successful(
             hash="0xdefault",
             cost=0,
             staked=0,
-            earned=int(appeal_bond * APPEAL_REWARD_MULTIPLE),
+            earned=successful_appeal_reward(appeal_bond),
             slashed=0,
             burned=0,
         )

--- a/src/fee_simulator/core/round_fee_distribution/appeal_leader_timeout_successful.py
+++ b/src/fee_simulator/core/round_fee_distribution/appeal_leader_timeout_successful.py
@@ -1,4 +1,4 @@
-from src.fee_simulator.protocol.constants import APPEAL_REWARD_MULTIPLE
+from src.fee_simulator.protocol.appeal_economics import successful_appeal_reward
 from typing import List
 from src.fee_simulator.protocol.models import (
     TransactionRoundResults,
@@ -54,7 +54,7 @@ def apply_appeal_leader_timeout_successful(
             round_index=round_index,
             round_label="APPEAL_LEADER_TIMEOUT_SUCCESSFUL",
             role="APPEALANT",
-            earned=int(appeal_bond * APPEAL_REWARD_MULTIPLE),
+            earned=successful_appeal_reward(appeal_bond),
         )
     )
     return events

--- a/src/fee_simulator/core/round_fee_distribution/appeal_validator_successful.py
+++ b/src/fee_simulator/core/round_fee_distribution/appeal_validator_successful.py
@@ -12,10 +12,8 @@ from src.fee_simulator.core.majority import (
     normalize_vote,
 )
 from src.fee_simulator.core.bond_computing import compute_appeal_bond
-from src.fee_simulator.protocol.constants import (
-    PENALTY_REWARD_COEFFICIENT,
-    APPEAL_REWARD_MULTIPLE,
-)
+from src.fee_simulator.protocol.constants import PENALTY_REWARD_COEFFICIENT
+from src.fee_simulator.protocol.appeal_economics import successful_appeal_reward
 from src.fee_simulator.utils import is_appeal_round
 from src.fee_simulator.utils_round_sizes import find_previous_normal_round
 
@@ -67,7 +65,7 @@ def apply_appeal_validator_successful(
             hash="0xdefault",
             cost=0,
             staked=0,
-            earned=int(appeal_bond * APPEAL_REWARD_MULTIPLE),
+            earned=successful_appeal_reward(appeal_bond),
             slashed=0,
             burned=0,
         )

--- a/src/fee_simulator/core/round_labeling.py
+++ b/src/fee_simulator/core/round_labeling.py
@@ -244,6 +244,14 @@ def classify_appeal_round(
 # Special case patterns
 SPECIAL_CASE_PATTERNS = [
     {
+        "name": "Skip round before terminal successful appeal",
+        "pattern": [
+            "NORMAL_ROUND",
+            ["APPEAL_LEADER_SUCCESSFUL", "APPEAL_VALIDATOR_SUCCESSFUL"],
+        ],
+        "changes": {0: "SKIP_ROUND"},
+    },
+    {
         "name": "Skip round before successful appeal",
         "pattern": [
             "NORMAL_ROUND",

--- a/src/fee_simulator/protocol/appeal_economics.py
+++ b/src/fee_simulator/protocol/appeal_economics.py
@@ -1,0 +1,17 @@
+from fractions import Fraction
+
+
+SUCCESS_REWARD_NUMERATOR = 5
+SUCCESS_REWARD_DENOMINATOR = 2
+APPEAL_REWARD_MULTIPLE = Fraction(
+    SUCCESS_REWARD_NUMERATOR, SUCCESS_REWARD_DENOMINATOR
+)
+
+
+def successful_appeal_reward(appeal_bond: int) -> int:
+    """Return principal plus profit using Solidity's integer division."""
+    return appeal_bond * SUCCESS_REWARD_NUMERATOR // SUCCESS_REWARD_DENOMINATOR
+
+
+def successful_appeal_profit(appeal_bond: int) -> int:
+    return successful_appeal_reward(appeal_bond) - appeal_bond

--- a/src/fee_simulator/protocol/constants.py
+++ b/src/fee_simulator/protocol/constants.py
@@ -1,3 +1,6 @@
+from src.fee_simulator.protocol.appeal_economics import APPEAL_REWARD_MULTIPLE
+
+
 ETH_ADDRESS_REGEX = r"^0x[a-fA-F0-9]{40}$"
 
 # Normal round sizes (for even-indexed rounds: 0, 2, 4, ...)
@@ -10,7 +13,7 @@ NORMAL_ROUND_SIZES = [
     191,  # Round 10
     383,  # Round 12
     767,  # Round 14
-    1000,  # Round 16+
+    1535,  # Round 16+
 ]
 
 # Appeal round sizes (for odd-indexed rounds: 1, 3, 5, ...)
@@ -23,15 +26,10 @@ APPEAL_ROUND_SIZES = [
     193,  # Round 11 (appeal 5)
     385,  # Round 13 (appeal 6)
     769,  # Round 15 (appeal 7)
-    1000,  # Round 17+ (appeal 8+)
+    1537,  # Round 17+ (appeal 8+)
 ]
 
 PENALTY_REWARD_COEFFICIENT = 1
-
-# Multiple of the appeal bond returned to a successful appellant:
-# principal (1.0) plus profit (APPEAL_REWARD_MULTIPLE - 1.0). Keep this value
-# in lockstep with the corresponding FeesProcessor constant.
-APPEAL_REWARD_MULTIPLE = 2.5
 
 DEFAULT_HASH = "0xdefault"
 DEFAULT_STAKE = 2000000

--- a/src/fee_simulator/protocol/types.py
+++ b/src/fee_simulator/protocol/types.py
@@ -1,6 +1,13 @@
 from typing import List, Literal, Union
 
-ValVote = Literal["AGREE", "DISAGREE", "TIMEOUT", "IDLE", "NA"]
+ValVote = Literal[
+    "AGREE",
+    "DISAGREE",
+    "TIMEOUT",
+    "DETERMINISTIC_VIOLATION",
+    "IDLE",
+    "NA",
+]
 LeaderAction = Literal["LEADER_RECEIPT", "LEADER_TIMEOUT"]
 Vote = Union[
     ValVote,
@@ -10,7 +17,13 @@ Vote = Union[
 ]
 Role = Literal["LEADER", "VALIDATOR", "SENDER", "APPEALANT", "TOPPER"]
 
-MajorityOutcome = Literal["AGREE", "DISAGREE", "TIMEOUT", "UNDETERMINED"]
+MajorityOutcome = Literal[
+    "AGREE",
+    "DISAGREE",
+    "TIMEOUT",
+    "DETERMINISTIC_VIOLATION",
+    "UNDETERMINED",
+]
 RoundLabel = Literal[
     "NORMAL_ROUND",
     "EMPTY_ROUND",

--- a/src/fee_simulator/utils.py
+++ b/src/fee_simulator/utils.py
@@ -13,8 +13,8 @@ from src.fee_simulator.protocol.constants import (
     DEFAULT_STAKE,
     NORMAL_ROUND_SIZES,
     APPEAL_ROUND_SIZES,
-    APPEAL_REWARD_MULTIPLE,
 )
+from src.fee_simulator.protocol.appeal_economics import successful_appeal_profit
 from src.fee_simulator.protocol.types import RoundLabel
 
 
@@ -94,7 +94,7 @@ def compute_total_cost(transaction_budget: TransactionBudget) -> int:
             transaction_budget.leaderTimeout
             + next_normal_size * transaction_budget.validatorsTimeout
         )
-        appeal_reward = int(appeal_bond * (APPEAL_REWARD_MULTIPLE - 1.0))  # profit above principal
+        appeal_reward = successful_appeal_profit(appeal_bond)
         total_appeal_rewards += appeal_reward
 
     total_cost = max_round_price + total_appeal_rewards

--- a/tests/fee_distributions/test_consensus_vector_conformance.py
+++ b/tests/fee_distributions/test_consensus_vector_conformance.py
@@ -5,6 +5,7 @@ import pytest
 from src.fee_simulator.analysis.consensus_vector_conformance import (
     ConsensusConformanceViolation,
     compare_case,
+    upgrade_case_to_current_appeal_economics,
 )
 
 
@@ -140,6 +141,19 @@ def test_future_economics_reaches_exact_parity_after_consensus_catches_up():
     assert delta.vindicated_count == 0
     assert delta.upfront_reserve_delta == 0
     assert delta.sender_refund_delta == 0
+
+
+def test_upgrades_legacy_case_without_regenerating_its_scenario():
+    legacy = vector_case()
+    future = upgrade_case_to_current_appeal_economics(
+        legacy,
+        source="fixture",
+        pattern="stable-upgrade",
+    )
+
+    assert future["initialState"] == legacy["initialState"]
+    assert future == vector_case(appellant_reward=3500, vindicate=True)
+    assert legacy == vector_case()
 
 
 def test_rejects_a_new_retroactive_penalty():

--- a/tests/fee_distributions/test_paper_payoff_properties.py
+++ b/tests/fee_distributions/test_paper_payoff_properties.py
@@ -52,8 +52,8 @@ def test_exhaustive_first_rung_paper_payoff_kernel():
     assert report.maximum_vindicated_count_observed == 2
     assert report.maximum_added_sender_cost_observed == 400
     assert report.configured_rung_boundary_cases_checked == 18
-    assert report.largest_configured_vindication_count == 499
-    assert report.largest_configured_added_sender_cost == 99800
+    assert report.largest_configured_vindication_count == 767
+    assert report.largest_configured_added_sender_cost == 153400
     assert report.appeal_reward_multiple == 2.5
     assert report.payoff_kernel == {
         "normal_clear_aligned": 200,

--- a/tests/fee_distributions/unit_tests/test_fee_distribution_functions.py
+++ b/tests/fee_distributions/unit_tests/test_fee_distribution_functions.py
@@ -443,6 +443,67 @@ class TestAppealValidatorSuccessful:
         assert all(e.earned == 200 for e in events if e.role == "VALIDATOR")
         assert not any(e.address in addresses_pool[0:5] for e in events)
 
+    def test_deterministic_violation_success_vindicates_matching_original_voters(self):
+        """A clear deterministic-violation reversal vindicates its original side."""
+        event_sequence = EventSequence()
+        transaction_results = TransactionRoundResults(
+            rounds=[
+                Round(
+                    rotations=[
+                        Rotation(
+                            votes={
+                                addresses_pool[0]: ["LEADER_RECEIPT", "AGREE"],
+                                addresses_pool[1]: "AGREE",
+                                addresses_pool[2]: "AGREE",
+                                addresses_pool[3]: "DETERMINISTIC_VIOLATION",
+                                addresses_pool[4]: "DETERMINISTIC_VIOLATION",
+                            }
+                        )
+                    ]
+                ),
+                Round(
+                    rotations=[
+                        Rotation(
+                            votes={
+                                addresses_pool[5]: "DETERMINISTIC_VIOLATION",
+                                addresses_pool[6]: "DETERMINISTIC_VIOLATION",
+                                addresses_pool[7]: "DETERMINISTIC_VIOLATION",
+                                addresses_pool[8]: "DETERMINISTIC_VIOLATION",
+                                addresses_pool[9]: "AGREE",
+                                addresses_pool[10]: "AGREE",
+                                addresses_pool[11]: "AGREE",
+                            }
+                        )
+                    ]
+                ),
+            ]
+        )
+        budget = TransactionBudget(
+            leaderTimeout=100,
+            validatorsTimeout=200,
+            appealRounds=1,
+            rotations=[0, 0],
+            senderAddress=addresses_pool[99],
+            appeals=[Appeal(appealantAddress=addresses_pool[98])],
+            staking_distribution="constant",
+        )
+
+        events = apply_appeal_validator_successful(
+            transaction_results=transaction_results,
+            round_index=1,
+            budget=budget,
+            event_sequence=event_sequence,
+            round_labels=["SKIP_ROUND", "APPEAL_VALIDATOR_SUCCESSFUL"],
+        )
+
+        for addr in addresses_pool[3:5]:
+            vindication_event = next(e for e in events if e.address == addr)
+            assert vindication_event.vote == "DETERMINISTIC_VIOLATION"
+            assert vindication_event.earned == 200
+            assert vindication_event.burned == 0
+        for addr in addresses_pool[0:3]:
+            assert not any(e.address == addr for e in events)
+
 
 class TestLeaderTimeout50Percent:
     """Unit tests for apply_leader_timeout_50_percent function."""

--- a/tests/protocol/test_appeal_economics.py
+++ b/tests/protocol/test_appeal_economics.py
@@ -1,0 +1,13 @@
+from src.fee_simulator.protocol.appeal_economics import (
+    APPEAL_REWARD_MULTIPLE,
+    successful_appeal_profit,
+    successful_appeal_reward,
+)
+
+
+def test_successful_appeal_economics_are_exact_integer_math():
+    bond = 10**30 + 1
+    assert APPEAL_REWARD_MULTIPLE.numerator == 5
+    assert APPEAL_REWARD_MULTIPLE.denominator == 2
+    assert successful_appeal_reward(bond) == bond * 5 // 2
+    assert successful_appeal_profit(bond) == bond * 5 // 2 - bond

--- a/tests/round_labeling/test_round_labeling.py
+++ b/tests/round_labeling/test_round_labeling.py
@@ -286,6 +286,42 @@ class TestSpecificPatterns:
         assert labels[1] == "APPEAL_LEADER_SUCCESSFUL"
         assert labels[2] == "NORMAL_ROUND"
 
+    def test_terminal_successful_validator_appeal_still_skips_original_round(self):
+        """The overturned round is skipped even when re-execution is not recorded yet."""
+        transaction_results = TransactionRoundResults(
+            rounds=[
+                Round(
+                    rotations=[
+                        Rotation(
+                            votes={
+                                addresses_pool[0]: ["LEADER_RECEIPT", "AGREE"],
+                                addresses_pool[1]: "AGREE",
+                                addresses_pool[2]: "AGREE",
+                                addresses_pool[3]: "DISAGREE",
+                                addresses_pool[4]: "DISAGREE",
+                            }
+                        )
+                    ]
+                ),
+                Round(
+                    rotations=[
+                        Rotation(
+                            votes={
+                                addresses_pool[5]: "DISAGREE",
+                                addresses_pool[6]: "DISAGREE",
+                                addresses_pool[7]: "DISAGREE",
+                                addresses_pool[8]: "AGREE",
+                                addresses_pool[9]: "AGREE",
+                            }
+                        )
+                    ]
+                ),
+            ]
+        )
+
+        labels = label_rounds(transaction_results)
+        assert labels == ["SKIP_ROUND", "APPEAL_VALIDATOR_SUCCESSFUL"]
+
     def test_leader_timeout_150_pattern(self):
         """Leader timeout + successful appeal + normal should trigger special labeling."""
         transaction_results = TransactionRoundResults(


### PR DESCRIPTION
## Delivery context

This handoff is stacked above #28 (`feat/parameterize-appeal-reward-multiple`). Admission-time quote checkpoints live in child PR #30. Consensus consumer: genlayerlabs/genlayer-consensus#1381.

## Outcome

- exact integer 5/2 appeal reward and 3/2 profit arithmetic, including huge odd bonds;
- configured validator ladder through the 1,535/1,537 terminal rounds;
- correct terminal successful-appeal round labels;
- deterministic-violation votes and vindication of proven-correct minority voters;
- validated in-place vector migration that changes only approved economics/conservation outputs;
- reproducible dependency pins for the oracle environment.

## Oracle boundary and why the first cross-check missed leader-timeout pricing

The historical conformance vectors begin **after appeal admission**. They validate settlement—rewards, penalties, fee custody, and refunds—but do not independently execute live validator selection, capacity-limited jury sizing, the public bond quote, or admission funding.

An integration test then replaced the simulator-derived appellant result in memory with the old Solidity quote. That made a five-seat configured leader-timeout basis look like a four-seat oracle result and masked the 1,100/900 disagreement.

This PR now documents and enforces that post-admission boundary. Child PR #30 is the separate admission-checkpoint oracle and records configured committee basis, selectable/capacity-limited jury count, rotations, remaining attempts, quote components, and exact minimum bond.

## Validation

- full suite: **1,022 passed, 5 skipped**;
- exact-arithmetic, payoff, round-label, deterministic-violation, and vector-conformance regressions;
- changed-file and diff checks: clean.

Current head: `58115643f733eedfa331f1b78243f4b373482704`.