### PR TITLE
[handoff] test: export appeal admission quote checkpoints

### DIFF
--- a/scripts/07_generate_consensus_vectors.py
+++ b/scripts/07_generate_consensus_vectors.py
@@ -39,7 +39,10 @@ from src.fee_simulator.core.path_to_transaction import path_to_transaction_resul
 from src.fee_simulator.core.bond_computing import compute_appeal_bond_quote
 from src.fee_simulator.core.transaction_processing import process_transaction
 from src.fee_simulator.core.majority import compute_majority, normalize_vote
-from src.fee_simulator.specification.state_machine.graph import TRANSACTION_GRAPH
+from src.fee_simulator.specification.state_machine.graph import (
+    TRANSACTION_GRAPH,
+    is_protocol_valid_path,
+)
 from src.fee_simulator.specification.state_machine.path_analysis.path_generator import (
     generate_all_paths,
 )
@@ -197,6 +200,10 @@ def build_appeal_quote_checkpoints(transaction_results, round_labels, budget):
         checkpoints.append(
             {
                 "appeal_round_index": quote.appeal_round_index,
+                # Simulator settlement-round positions and raw protocol round
+                # indexes diverge after chained appeals. Admission happens
+                # against the live raw round immediately before this appeal.
+                "quote_round_index": quote.appeal_round_index - 1,
                 "source_round_index": quote.source_round_index,
                 "source_decision": source_decision,
                 "source_round_label": source_round_label,
@@ -399,8 +406,9 @@ def main():
     sender = addresses_pool[-1]
     appealant = addresses_pool[-2]
 
-    paths = list(
-        generate_all_paths(
+    paths = [
+        path
+        for path in generate_all_paths(
             TRANSACTION_GRAPH,
             PathConstraints(
                 # min_length=2 keeps the single-round (no appeal) paths
@@ -410,7 +418,8 @@ def main():
                 target_node="END",
             ),
         )
-    )
+        if is_protocol_valid_path(path)
+    ]
     print(f"paths: {len(paths)}")
 
     # category -> pattern -> examples (base and rotations kept separate)
@@ -474,14 +483,13 @@ def main():
 
     # A uniform funded schedule cannot distinguish raw consensus-round indexes
     # from normal-round ordinals. Include one valid non-uniform schedule with
-    # no rotations actually consumed: runtime capacity clamps to zero, but the
-    # later Undetermined quote must still read rotations[2] and price three
-    # attempts for raw round 4. This would have caught the former round-1 bug
-    # in both Consensus and Studio.
+    # no rotations actually consumed. Two successive leader replays exercise
+    # rotations[1] and rotations[2] without attempting to appeal a terminal
+    # normal decision after a successful validator review.
     ordinal_probe_path = [
         "START",
-        "LEADER_RECEIPT_MAJORITY_AGREE",
-        "VALIDATOR_APPEAL_SUCCESSFUL",
+        "LEADER_RECEIPT_UNDETERMINED",
+        "LEADER_APPEAL_UNSUCCESSFUL",
         "LEADER_RECEIPT_UNDETERMINED",
         "LEADER_APPEAL_SUCCESSFUL",
         "LEADER_RECEIPT_MAJORITY_AGREE",
@@ -568,7 +576,7 @@ def main():
     with open(quote_output, "w") as f:
         json.dump(
             {
-                "schema_version": 2,
+                "schema_version": 3,
                 "description": (
                     "Simulator appeal-price checkpoints selected to cover every "
                     "status, committee basis, committee size, and attempt count. "

--- a/scripts/07_generate_consensus_vectors.py
+++ b/scripts/07_generate_consensus_vectors.py
@@ -174,6 +174,11 @@ def build_appeal_quote_checkpoints(transaction_results, round_labels, budget):
     """Export every appeal-boundary quote, including its pricing provenance."""
 
     checkpoints = []
+    # Track the live raw Consensus round pointer. Simulator round-label indexes
+    # are settlement positions: consecutive failed validator appeals advance
+    # the raw pointer 0 -> 1 -> 3, while leader appeals replace the source with
+    # a new normal round two raw slots later.
+    quote_round_index = 0
     for appeal_round_index, label in enumerate(round_labels):
         if not is_appeal_round(label):
             continue
@@ -200,10 +205,7 @@ def build_appeal_quote_checkpoints(transaction_results, round_labels, budget):
         checkpoints.append(
             {
                 "appeal_round_index": quote.appeal_round_index,
-                # Simulator settlement-round positions and raw protocol round
-                # indexes diverge after chained appeals. Admission happens
-                # against the live raw round immediately before this appeal.
-                "quote_round_index": quote.appeal_round_index - 1,
+                "quote_round_index": quote_round_index,
                 "source_round_index": quote.source_round_index,
                 "source_decision": source_decision,
                 "source_round_label": source_round_label,
@@ -221,6 +223,10 @@ def build_appeal_quote_checkpoints(transaction_results, round_labels, budget):
                 "expected_bond": str(quote.total),
             }
         )
+        if label.startswith("APPEAL_LEADER"):
+            quote_round_index += 2
+        else:
+            quote_round_index += 1 if quote_round_index % 2 == 0 else 2
     return checkpoints
 
 
@@ -576,7 +582,7 @@ def main():
     with open(quote_output, "w") as f:
         json.dump(
             {
-                "schema_version": 3,
+                "schema_version": 4,
                 "description": (
                     "Simulator appeal-price checkpoints selected to cover every "
                     "status, committee basis, committee size, and attempt count. "

--- a/scripts/07_generate_consensus_vectors.py
+++ b/scripts/07_generate_consensus_vectors.py
@@ -188,6 +188,7 @@ def build_appeal_quote_checkpoints(transaction_results, round_labels, budget):
             round_labels=round_labels,
             appeal_round_index=appeal_round_index,
             rotations=budget.rotations,
+            rotations_used=budget.rotationsUsed,
         )
         source_round_label = round_labels[source_round_index]
         source_decision, source_status = appeal_source_decision(
@@ -203,6 +204,8 @@ def build_appeal_quote_checkpoints(transaction_results, round_labels, budget):
                 "appeal_label": quote.appeal_label,
                 "committee_basis": quote.committee_basis,
                 "committee_size": quote.committee_size,
+                "attempt_basis": quote.attempt_basis,
+                "rotations_value": quote.rotations_value,
                 "attempts": quote.attempts,
                 "leader_unit": str(quote.leader_unit),
                 "validator_unit": str(quote.validator_unit),
@@ -215,7 +218,13 @@ def build_appeal_quote_checkpoints(transaction_results, round_labels, budget):
 
 
 def build_example(
-    path, rotation_counts, addresses_pool, sender, appealant, rotation_kind="timeout"
+    path,
+    rotation_counts,
+    addresses_pool,
+    sender,
+    appealant,
+    rotation_kind="timeout",
+    funded_rotations=None,
 ):
     transaction_results, budget = path_to_transaction_results(
         path=path,
@@ -227,6 +236,18 @@ def build_example(
         rotation_counts=rotation_counts or {},
         rotation_kind=rotation_kind,
     )
+    if funded_rotations is not None:
+        funded_rotations = list(funded_rotations)
+        if len(funded_rotations) != len(budget.rotations):
+            raise ValueError(
+                "funded rotation override must align with normal rounds: "
+                f"{len(funded_rotations)} != {len(budget.rotations)}"
+            )
+        # Keep actual rotations from the generated path, but let quote-only
+        # diagnostics exercise a non-uniform funded schedule. This is valid on
+        # Consensus: runtime capacity is clamped to the smallest entry, while
+        # an Undetermined bond still reads the configured future-round entry.
+        budget = budget.model_copy(update={"rotations": funded_rotations})
     fee_events, round_labels = process_transaction(
         addresses=addresses_pool,
         transaction_results=transaction_results,
@@ -299,6 +320,9 @@ def build_example(
 
     total_rotations = sum((rotation_counts or {}).values())
     name = pattern_name(path, total_rotations, rotation_kind)
+    if funded_rotations is not None:
+        schedule = ",".join(str(value) for value in funded_rotations)
+        name = f"{name} [funded:{schedule}]"
     appeal_quotes = build_appeal_quote_checkpoints(
         transaction_results, round_labels, budget
     )
@@ -317,6 +341,7 @@ def build_example(
     }
     if appeal_quotes:
         example["checkpoints"] = {"appeal_quotes": appeal_quotes}
+    example["funded_rotations"] = budget.rotations
     if total_rotations:
         rot_list = [
             (rotation_counts or {}).get(k, 0)
@@ -429,6 +454,8 @@ def main():
                     quote["source_status"],
                     quote["committee_basis"],
                     quote["committee_size"],
+                    quote["attempt_basis"],
+                    quote["rotations_value"],
                     quote["attempts"],
                 )
                 candidate = {
@@ -444,6 +471,45 @@ def main():
                 current = quote_candidates.get(signature)
                 if current is None or rank < current[0]:
                     quote_candidates[signature] = (rank, candidate)
+
+    # A uniform funded schedule cannot distinguish raw consensus-round indexes
+    # from normal-round ordinals. Include one valid non-uniform schedule with
+    # no rotations actually consumed: runtime capacity clamps to zero, but the
+    # later Undetermined quote must still read rotations[2] and price three
+    # attempts for raw round 4. This would have caught the former round-1 bug
+    # in both Consensus and Studio.
+    ordinal_probe_path = [
+        "START",
+        "LEADER_RECEIPT_MAJORITY_AGREE",
+        "VALIDATOR_APPEAL_SUCCESSFUL",
+        "LEADER_RECEIPT_UNDETERMINED",
+        "LEADER_APPEAL_SUCCESSFUL",
+        "LEADER_RECEIPT_MAJORITY_AGREE",
+        "END",
+    ]
+    name, example = build_example(
+        ordinal_probe_path,
+        {},
+        addresses_pool,
+        sender,
+        appealant,
+        funded_rotations=[0, 1, 2],
+    )
+    category = categorize(ordinal_probe_path)
+    for quote in example.get("checkpoints", {}).get("appeal_quotes", []):
+        signature = (
+            quote["source_status"],
+            quote["committee_basis"],
+            quote["committee_size"],
+            quote["attempt_basis"],
+            quote["rotations_value"],
+            quote["attempts"],
+        )
+        candidate = {"category": category, "pattern": name, "example": example}
+        rank = (len(example["initialState"]["rounds"]), 0, name)
+        current = quote_candidates.get(signature)
+        if current is None or rank < current[0]:
+            quote_candidates[signature] = (rank, candidate)
 
     def write_category(category, patterns, suffix):
         data = {
@@ -502,19 +568,25 @@ def main():
     with open(quote_output, "w") as f:
         json.dump(
             {
-                "schema_version": 1,
+                "schema_version": 2,
                 "description": (
                     "Simulator appeal-price checkpoints selected to cover every "
-                    "status, committee basis, committee size, and attempt count."
+                    "status, committee basis, committee size, and attempt count. "
+                    "Funded rotation schedules and actual usage are separate so "
+                    "admission quotes use the same provenance as Consensus."
                 ),
                 "covered_signatures": [
                     {
                         "source_status": status,
                         "committee_basis": basis,
                         "committee_size": size,
+                        "attempt_basis": attempt_basis,
+                        "rotations_value": rotations_value,
                         "attempts": attempts,
                     }
-                    for status, basis, size, attempts in sorted(quote_signatures)
+                    for status, basis, size, attempt_basis, rotations_value, attempts in sorted(
+                        quote_signatures
+                    )
                 ],
                 "cases": quote_campaign,
             },

--- a/scripts/07_generate_consensus_vectors.py
+++ b/scripts/07_generate_consensus_vectors.py
@@ -14,7 +14,11 @@ whenever the fee model changes:
 Outputs, per category (first appeal node in the path, or no_appeal):
   <category>_compressed.json            (variants without rotations)
   <category>_rotations_compressed.json  (variants with rotations)
+  appeal_quote_checkpoints.json         (compact transition-quote campaign)
   summary.json
+
+Use --appeal-quote-output to place the compact campaign directly in a
+consensus checkout while leaving the larger category vectors in --output-dir.
 
 If --existing-dir is given, the complex-scenario directories found there
 (*_complex_scenarios/, leader_timeout_complex_scenarios/) are rebuilt
@@ -24,6 +28,7 @@ re-running each pattern through the current simulator.
 
 import argparse
 import json
+import random
 import sys
 from collections import defaultdict
 from pathlib import Path
@@ -31,8 +36,9 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from src.fee_simulator.core.path_to_transaction import path_to_transaction_results
+from src.fee_simulator.core.bond_computing import compute_appeal_bond_quote
 from src.fee_simulator.core.transaction_processing import process_transaction
-from src.fee_simulator.core.majority import normalize_vote
+from src.fee_simulator.core.majority import compute_majority, normalize_vote
 from src.fee_simulator.specification.state_machine.graph import TRANSACTION_GRAPH
 from src.fee_simulator.specification.state_machine.path_analysis.path_generator import (
     generate_all_paths,
@@ -43,7 +49,8 @@ from src.fee_simulator.specification.state_machine.path_analysis.path_types impo
 from src.fee_simulator.specification.state_machine.path_analysis.variant_generator import (
     generate_all_path_variants,
 )
-from src.fee_simulator.utils import generate_random_eth_address
+from src.fee_simulator.utils import generate_random_eth_address, is_appeal_round
+from src.fee_simulator.utils_round_sizes import find_previous_normal_round
 
 LEADER_TIMEOUT = 100
 VALIDATORS_TIMEOUT = 200
@@ -119,15 +126,97 @@ class AddressBook:
 
 
 def leader_vote_string(vote):
-    if isinstance(vote, list) and vote and vote[0] in (
-        "LEADER_RECEIPT",
-        "LEADER_TIMEOUT",
+    if (
+        isinstance(vote, list)
+        and vote
+        and vote[0]
+        in (
+            "LEADER_RECEIPT",
+            "LEADER_TIMEOUT",
+        )
     ):
         return vote[0]
     return normalize_vote(vote)
 
 
-def build_example(path, rotation_counts, addresses_pool, sender, appealant, rotation_kind="timeout"):
+def appeal_source_decision(source_round, source_round_label, appeal_label):
+    """Return the source decision and contract status from processed rounds.
+
+    The appeal label is the simulator's contextual classification of the
+    admission state: leader-timeout and undetermined appeals can originate from
+    rounds later recolored as SKIP for settlement.  Validator appeals still need
+    their processed majority to distinguish Accepted from ValidatorsTimeout.
+    This deliberately avoids indexing back into the graph path because graph
+    nodes and processed round indices diverge in chained scenarios.
+    """
+
+    if appeal_label.startswith("APPEAL_LEADER_TIMEOUT"):
+        return "LEADER_TIMEOUT", "LeaderTimeout"
+
+    votes = source_round.rotations[-1].votes if source_round.rotations else {}
+    majority = compute_majority(votes)
+    if appeal_label.startswith("APPEAL_LEADER"):
+        return f"LEADER_RECEIPT_{majority}", "Undetermined"
+    if majority == "TIMEOUT":
+        return "LEADER_RECEIPT_MAJORITY_TIMEOUT", "ValidatorsTimeout"
+    if majority == "AGREE":
+        return "LEADER_RECEIPT_MAJORITY_AGREE", "Accepted"
+    raise ValueError(
+        f"Unsupported validator-appeal source majority {majority} "
+        f"from {source_round_label}"
+    )
+
+
+def build_appeal_quote_checkpoints(transaction_results, round_labels, budget):
+    """Export every appeal-boundary quote, including its pricing provenance."""
+
+    checkpoints = []
+    for appeal_round_index, label in enumerate(round_labels):
+        if not is_appeal_round(label):
+            continue
+        source_round_index = find_previous_normal_round(
+            appeal_round_index, round_labels
+        )
+        if source_round_index is None:
+            raise ValueError(
+                f"Appeal round {appeal_round_index} has no source normal round"
+            )
+        quote = compute_appeal_bond_quote(
+            normal_round_index=source_round_index,
+            leader_timeout=budget.leaderTimeout,
+            validators_timeout=budget.validatorsTimeout,
+            round_labels=round_labels,
+            appeal_round_index=appeal_round_index,
+            rotations=budget.rotations,
+        )
+        source_round_label = round_labels[source_round_index]
+        source_decision, source_status = appeal_source_decision(
+            transaction_results.rounds[source_round_index], source_round_label, label
+        )
+        checkpoints.append(
+            {
+                "appeal_round_index": quote.appeal_round_index,
+                "source_round_index": quote.source_round_index,
+                "source_decision": source_decision,
+                "source_round_label": source_round_label,
+                "source_status": source_status,
+                "appeal_label": quote.appeal_label,
+                "committee_basis": quote.committee_basis,
+                "committee_size": quote.committee_size,
+                "attempts": quote.attempts,
+                "leader_unit": str(quote.leader_unit),
+                "validator_unit": str(quote.validator_unit),
+                "leader_component": str(quote.leader_component),
+                "validator_component": str(quote.validator_component),
+                "expected_bond": str(quote.total),
+            }
+        )
+    return checkpoints
+
+
+def build_example(
+    path, rotation_counts, addresses_pool, sender, appealant, rotation_kind="timeout"
+):
     transaction_results, budget = path_to_transaction_results(
         path=path,
         addresses=addresses_pool,
@@ -155,16 +244,14 @@ def build_example(path, rotation_counts, addresses_pool, sender, appealant, rota
         first_addr = next(iter(votes.keys()), None)
         validators_out = []
         for addr, vote in votes.items():
-            is_leader = addr == first_addr and not round_labels[i].startswith(
-                "APPEAL_"
-            )
+            is_leader = addr == first_addr and not round_labels[i].startswith("APPEAL_")
             validators_out.append(
                 {
                     "address": book.name(addr),
                     "stake": DEFAULT_STAKE,
-                    "vote": leader_vote_string(vote)
-                    if is_leader
-                    else normalize_vote(vote),
+                    "vote": (
+                        leader_vote_string(vote) if is_leader else normalize_vote(vote)
+                    ),
                     "is_leader": is_leader,
                 }
             )
@@ -212,6 +299,9 @@ def build_example(path, rotation_counts, addresses_pool, sender, appealant, rota
 
     total_rotations = sum((rotation_counts or {}).values())
     name = pattern_name(path, total_rotations, rotation_kind)
+    appeal_quotes = build_appeal_quote_checkpoints(
+        transaction_results, round_labels, budget
+    )
     example = {
         "description": f"Test Case: {name}",
         "initialState": {"rounds": rounds_out, "sender": "sender"},
@@ -225,6 +315,8 @@ def build_example(path, rotation_counts, addresses_pool, sender, appealant, rota
             },
         },
     }
+    if appeal_quotes:
+        example["checkpoints"] = {"appeal_quotes": appeal_quotes}
     if total_rotations:
         rot_list = [
             (rotation_counts or {}).get(k, 0)
@@ -253,6 +345,20 @@ def main():
     parser.add_argument("--max-length", type=int, default=7)
     parser.add_argument("--max-rotations", type=int, default=2)
     parser.add_argument(
+        "--seed",
+        type=int,
+        default=0,
+        help="Seed for deterministic validator-address generation (default: 0).",
+    )
+    parser.add_argument(
+        "--appeal-quote-output",
+        default=None,
+        help=(
+            "Optional standalone path for the compact appeal-quote campaign. "
+            "The full category vectors still go to --output-dir."
+        ),
+    )
+    parser.add_argument(
         "--existing-dir",
         default=None,
         help="Existing simulator_results dir; complex-scenario dirs are rebuilt "
@@ -263,6 +369,7 @@ def main():
     out = Path(args.output_dir)
     out.mkdir(parents=True, exist_ok=True)
 
+    random.seed(args.seed)
     addresses_pool = [generate_random_eth_address() for _ in range(5000)]
     sender = addresses_pool[-1]
     appealant = addresses_pool[-2]
@@ -286,6 +393,7 @@ def main():
     rot = defaultdict(lambda: defaultdict(list))
     counts = defaultdict(int)
     errors = []
+    quote_candidates = {}
 
     for variant in generate_all_path_variants(
         paths, max_rotations=args.max_rotations, max_idle=0
@@ -314,6 +422,28 @@ def main():
             if len(bucket[category][name]) < max_examples:
                 bucket[category][name].append(example)
             counts[category] += 1
+
+            quotes = example.get("checkpoints", {}).get("appeal_quotes", [])
+            for quote in quotes:
+                signature = (
+                    quote["source_status"],
+                    quote["committee_basis"],
+                    quote["committee_size"],
+                    quote["attempts"],
+                )
+                candidate = {
+                    "category": category,
+                    "pattern": name,
+                    "example": example,
+                }
+                rank = (
+                    len(example["initialState"]["rounds"]),
+                    total_rotations,
+                    name,
+                )
+                current = quote_candidates.get(signature)
+                if current is None or rank < current[0]:
+                    quote_candidates[signature] = (rank, candidate)
 
     def write_category(category, patterns, suffix):
         data = {
@@ -354,6 +484,48 @@ def main():
             indent="\t",
         )
 
+    quote_signatures = set(quote_candidates)
+    quote_campaign_by_pattern = {}
+    for _, candidate in quote_candidates.values():
+        key = (candidate["category"], candidate["pattern"])
+        quote_campaign_by_pattern[key] = candidate
+    quote_campaign = [
+        quote_campaign_by_pattern[key] for key in sorted(quote_campaign_by_pattern)
+    ]
+
+    quote_output = (
+        Path(args.appeal_quote_output)
+        if args.appeal_quote_output
+        else out / "appeal_quote_checkpoints.json"
+    )
+    quote_output.parent.mkdir(parents=True, exist_ok=True)
+    with open(quote_output, "w") as f:
+        json.dump(
+            {
+                "schema_version": 1,
+                "description": (
+                    "Simulator appeal-price checkpoints selected to cover every "
+                    "status, committee basis, committee size, and attempt count."
+                ),
+                "covered_signatures": [
+                    {
+                        "source_status": status,
+                        "committee_basis": basis,
+                        "committee_size": size,
+                        "attempts": attempts,
+                    }
+                    for status, basis, size, attempts in sorted(quote_signatures)
+                ],
+                "cases": quote_campaign,
+            },
+            f,
+            indent="\t",
+        )
+    print(
+        f"wrote {quote_output} "
+        f"({len(quote_campaign)} cases, {len(quote_signatures)} signatures)"
+    )
+
     # Rebuild complex-scenario files keeping existing pattern keys
     if args.existing_dir:
         existing = Path(args.existing_dir)
@@ -371,9 +543,7 @@ def main():
                     path = ["START"] + core.split(" -> ") + ["END"]
                     old_ex = pd["examples"][0] if pd.get("examples") else {}
                     rot_list = old_ex.get("rotations") or []
-                    rotation_counts = {
-                        i: r for i, r in enumerate(rot_list) if r
-                    }
+                    rotation_counts = {i: r for i, r in enumerate(rot_list) if r}
                     try:
                         gen_name, example = build_example(
                             path,

--- a/src/fee_simulator/analysis/paper_payoff_kernel.py
+++ b/src/fee_simulator/analysis/paper_payoff_kernel.py
@@ -291,6 +291,7 @@ def certify_successful_validator_appeal(
         round_labels=round_labels,
         appeal_round_index=round_index,
         rotations=budget.rotations,
+        rotations_used=budget.rotationsUsed,
     )
     appellant_address = budget.appeals[
         sum(1 for label in round_labels[: round_index + 1] if is_appeal_round(label))

--- a/src/fee_simulator/core/bond_computing.py
+++ b/src/fee_simulator/core/bond_computing.py
@@ -4,6 +4,7 @@ from src.fee_simulator.utils_round_sizes import (
     get_round_size,
     get_round_size_for_bond,
     get_appeal_index,
+    get_normal_round_index,
     get_normal_round_size,
 )
 from src.fee_simulator.protocol.types import RoundLabel
@@ -19,6 +20,8 @@ class AppealBondQuote:
     appeal_label: RoundLabel
     committee_basis: str
     committee_size: int
+    attempt_basis: str
+    rotations_value: int
     attempts: int
     leader_unit: int
     validator_unit: int
@@ -55,6 +58,7 @@ def compute_appeal_bond(
     round_labels: List[RoundLabel],
     appeal_round_index: int = None,
     rotations: Optional[List[int]] = None,
+    rotations_used: Optional[List[int]] = None,
 ) -> int:
     """
     Compute the minimum appeal bond, mirroring the on-chain formulas
@@ -72,13 +76,16 @@ def compute_appeal_bond(
       leader rotations.
 
     - Leader timeout appeal (LeaderTimeout):
-        bond = (rotations_next + 1) * (leader_timeout + configured_source_round_size * validators_timeout)
+        bond = (live_source_rotations_left + 1) * (leader_timeout + configured_source_round_size * validators_timeout)
       The induced round later drops the timed-out leader, but participant
       removal does not rewrite the configured round-cost basis quoted at
       appeal admission.
 
-    `rotations` is the per-normal-round rotations list from the transaction
-    budget; when omitted, 0 extra rotations are assumed.
+    `rotations` is the funded per-normal-round schedule. `rotations_used` is
+    the corresponding actual usage. When usage is omitted, no rotations are
+    assumed consumed. This distinction mirrors the contract: Undetermined
+    quotes read the configured future schedule, while LeaderTimeout quotes
+    read the live source-round remainder.
     """
 
     return compute_appeal_bond_quote(
@@ -88,6 +95,7 @@ def compute_appeal_bond(
         round_labels=round_labels,
         appeal_round_index=appeal_round_index,
         rotations=rotations,
+        rotations_used=rotations_used,
     ).total
 
 
@@ -98,6 +106,7 @@ def compute_appeal_bond_quote(
     round_labels: List[RoundLabel],
     appeal_round_index: int = None,
     rotations: Optional[List[int]] = None,
+    rotations_used: Optional[List[int]] = None,
 ) -> AppealBondQuote:
     """Return the minimum bond together with every pricing input.
 
@@ -144,14 +153,42 @@ def compute_appeal_bond_quote(
             # does not rewrite the configured round-cost basis.
             committee_size = get_round_size(normal_round_index, round_labels)
             committee_basis = "configured_source_round"
+            attempt_basis = "live_source_round"
+
+            # Creation clamps tx.initialRotations to the smallest funded
+            # schedule entry. Leader-timeout replays inherit the remaining
+            # capacity, so chained timeout appeals must subtract usage from
+            # every normal round in the inherited replay chain.
+            initial_rotations = min(rotations) if rotations else 0
+            used_total = 0
+            cursor = normal_round_index
+            while True:
+                normal_ordinal = get_normal_round_index(cursor, round_labels)
+                if rotations_used is not None and normal_ordinal < len(rotations_used):
+                    used_total += rotations_used[normal_ordinal]
+                if (
+                    cursor == 0
+                    or round_labels[cursor - 1] not in LEADER_TIMEOUT_APPEAL_LABELS
+                ):
+                    break
+                previous_normal = cursor - 2
+                while previous_normal >= 0 and is_appeal_round(
+                    round_labels[previous_normal]
+                ):
+                    previous_normal -= 1
+                if previous_normal < 0:
+                    break
+                cursor = previous_normal
+            rotations_for_quote = max(initial_rotations - used_total, 0)
         else:
             # Undetermined appeal: full next normal round (round + 2 schedule)
             committee_size = get_normal_round_size(appeal_index + 1)
             committee_basis = "configured_next_normal_round"
-        rotations_next = 0
-        if rotations is not None and (appeal_index + 1) < len(rotations):
-            rotations_next = rotations[appeal_index + 1]
-        attempts = rotations_next + 1
+            attempt_basis = "configured_next_normal_round"
+            rotations_for_quote = 0
+            if rotations is not None and (appeal_index + 1) < len(rotations):
+                rotations_for_quote = rotations[appeal_index + 1]
+        attempts = rotations_for_quote + 1
         leader_component = attempts * leader_timeout
         validator_component = attempts * committee_size * validators_timeout
         return AppealBondQuote(
@@ -160,6 +197,8 @@ def compute_appeal_bond_quote(
             appeal_label=label,
             committee_basis=committee_basis,
             committee_size=committee_size,
+            attempt_basis=attempt_basis,
+            rotations_value=rotations_for_quote,
             attempts=attempts,
             leader_unit=leader_timeout,
             validator_unit=validators_timeout,
@@ -178,6 +217,8 @@ def compute_appeal_bond_quote(
         appeal_label=label,
         committee_basis="configured_appeal_round",
         committee_size=appeal_round_size,
+        attempt_basis="single_appeal_jury",
+        rotations_value=0,
         attempts=1,
         leader_unit=leader_timeout,
         validator_unit=validators_timeout,

--- a/src/fee_simulator/core/bond_computing.py
+++ b/src/fee_simulator/core/bond_computing.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from src.fee_simulator.utils import is_appeal_round
 from src.fee_simulator.utils_round_sizes import (
     get_round_size,
@@ -7,6 +8,24 @@ from src.fee_simulator.utils_round_sizes import (
 )
 from src.fee_simulator.protocol.types import RoundLabel
 from typing import List, Optional
+
+
+@dataclass(frozen=True)
+class AppealBondQuote:
+    """Auditable component breakdown for one minimum appeal-bond quote."""
+
+    source_round_index: int
+    appeal_round_index: int
+    appeal_label: RoundLabel
+    committee_basis: str
+    committee_size: int
+    attempts: int
+    leader_unit: int
+    validator_unit: int
+    leader_component: int
+    validator_component: int
+    total: int
+
 
 # Leader appeals from UNDETERMINED. Their bond covers the full cost of the
 # next normal round the appeal triggers (round + 2 schedule), matching
@@ -18,10 +37,9 @@ LEADER_APPEAL_LABELS = frozenset(
     ]
 )
 
-# Leader appeals from LEADER_TIMEOUT. The induced round ROTATES the existing
-# committee (no new validators — RoundsCreation.createNewLeaderTimeoutAppealRound),
-# so the bond covers the current committee size, matching
-# FeeManager.calculateMinAppealBond (LeaderTimeout branch).
+# Leader appeals from LEADER_TIMEOUT. The bond prices the configured source
+# round. The induced round later drops the timed-out leader, but that participant
+# removal does not rewrite the round-cost basis quoted at appeal admission.
 LEADER_TIMEOUT_APPEAL_LABELS = frozenset(
     [
         "APPEAL_LEADER_TIMEOUT_SUCCESSFUL",
@@ -54,13 +72,39 @@ def compute_appeal_bond(
       leader rotations.
 
     - Leader timeout appeal (LeaderTimeout):
-        bond = (rotations_next + 1) * (leader_timeout + current_committee_size * validators_timeout)
-      The induced round rotates the EXISTING committee (no new validators),
-      so the bond covers the current committee size, not the round + 2
-      schedule.
+        bond = (rotations_next + 1) * (leader_timeout + configured_source_round_size * validators_timeout)
+      The induced round later drops the timed-out leader, but participant
+      removal does not rewrite the configured round-cost basis quoted at
+      appeal admission.
 
     `rotations` is the per-normal-round rotations list from the transaction
     budget; when omitted, 0 extra rotations are assumed.
+    """
+
+    return compute_appeal_bond_quote(
+        normal_round_index=normal_round_index,
+        leader_timeout=leader_timeout,
+        validators_timeout=validators_timeout,
+        round_labels=round_labels,
+        appeal_round_index=appeal_round_index,
+        rotations=rotations,
+    ).total
+
+
+def compute_appeal_bond_quote(
+    normal_round_index: int,
+    leader_timeout: int,
+    validators_timeout: int,
+    round_labels: List[RoundLabel],
+    appeal_round_index: int = None,
+    rotations: Optional[List[int]] = None,
+) -> AppealBondQuote:
+    """Return the minimum bond together with every pricing input.
+
+    Consensus conformance tests consume this breakdown at the appeal boundary.
+    Keeping it beside :func:`compute_appeal_bond` prevents vector exporters from
+    reimplementing the formula or inferring the committee basis from final
+    payouts after the fact.
     """
 
     # Validate this is actually a normal round index
@@ -95,21 +139,49 @@ def compute_appeal_bond(
     if label in LEADER_APPEAL_LABELS or label in LEADER_TIMEOUT_APPEAL_LABELS:
         appeal_index = get_appeal_index(appeal_round_index, round_labels)
         if label in LEADER_TIMEOUT_APPEAL_LABELS:
-            # Timeout appeal: the induced round reuses the current committee
+            # Timeout appeal: price the configured source round. The later
+            # induced round drops the timed-out leader, but participant removal
+            # does not rewrite the configured round-cost basis.
             committee_size = get_round_size(normal_round_index, round_labels)
+            committee_basis = "configured_source_round"
         else:
             # Undetermined appeal: full next normal round (round + 2 schedule)
             committee_size = get_normal_round_size(appeal_index + 1)
+            committee_basis = "configured_next_normal_round"
         rotations_next = 0
         if rotations is not None and (appeal_index + 1) < len(rotations):
             rotations_next = rotations[appeal_index + 1]
         attempts = rotations_next + 1
-        total_cost = attempts * (
-            leader_timeout + committee_size * validators_timeout
+        leader_component = attempts * leader_timeout
+        validator_component = attempts * committee_size * validators_timeout
+        return AppealBondQuote(
+            source_round_index=normal_round_index,
+            appeal_round_index=appeal_round_index,
+            appeal_label=label,
+            committee_basis=committee_basis,
+            committee_size=committee_size,
+            attempts=attempts,
+            leader_unit=leader_timeout,
+            validator_unit=validators_timeout,
+            leader_component=leader_component,
+            validator_component=validator_component,
+            total=max(leader_component + validator_component, 0),
         )
-        return max(total_cost, 0)
 
     # Validator appeal: bond covers only the N+2 appeal validators voting
     # on the existing proposal (no leader fee component)
     appeal_round_size = get_round_size_for_bond(appeal_round_index, round_labels)
-    return max(appeal_round_size * validators_timeout, 0)
+    validator_component = appeal_round_size * validators_timeout
+    return AppealBondQuote(
+        source_round_index=normal_round_index,
+        appeal_round_index=appeal_round_index,
+        appeal_label=label,
+        committee_basis="configured_appeal_round",
+        committee_size=appeal_round_size,
+        attempts=1,
+        leader_unit=leader_timeout,
+        validator_unit=validators_timeout,
+        leader_component=0,
+        validator_component=validator_component,
+        total=max(validator_component, 0),
+    )

--- a/src/fee_simulator/core/bond_computing.py
+++ b/src/fee_simulator/core/bond_computing.py
@@ -4,7 +4,6 @@ from src.fee_simulator.utils_round_sizes import (
     get_round_size,
     get_round_size_for_bond,
     get_appeal_index,
-    get_normal_round_index,
     get_normal_round_size,
 )
 from src.fee_simulator.protocol.types import RoundLabel
@@ -76,16 +75,16 @@ def compute_appeal_bond(
       leader rotations.
 
     - Leader timeout appeal (LeaderTimeout):
-        bond = (live_source_rotations_left + 1) * (leader_timeout + configured_source_round_size * validators_timeout)
+        bond = (rotations_next + 1) * (leader_timeout + configured_source_round_size * validators_timeout)
       The induced round later drops the timed-out leader, but participant
       removal does not rewrite the configured round-cost basis quoted at
       appeal admission.
 
     `rotations` is the funded per-normal-round schedule. `rotations_used` is
     the corresponding actual usage. When usage is omitted, no rotations are
-    assumed consumed. This distinction mirrors the contract: Undetermined
-    quotes read the configured future schedule, while LeaderTimeout quotes
-    read the live source-round remainder.
+    assumed consumed. Usage is exported as separate provenance, but appeal
+    admission prices the configured round the appeal buys rather than prior
+    attempts already consumed.
     """
 
     return compute_appeal_bond_quote(
@@ -153,33 +152,10 @@ def compute_appeal_bond_quote(
             # does not rewrite the configured round-cost basis.
             committee_size = get_round_size(normal_round_index, round_labels)
             committee_basis = "configured_source_round"
-            attempt_basis = "live_source_round"
-
-            # Creation clamps tx.initialRotations to the smallest funded
-            # schedule entry. Leader-timeout replays inherit the remaining
-            # capacity, so chained timeout appeals must subtract usage from
-            # every normal round in the inherited replay chain.
-            initial_rotations = min(rotations) if rotations else 0
-            used_total = 0
-            cursor = normal_round_index
-            while True:
-                normal_ordinal = get_normal_round_index(cursor, round_labels)
-                if rotations_used is not None and normal_ordinal < len(rotations_used):
-                    used_total += rotations_used[normal_ordinal]
-                if (
-                    cursor == 0
-                    or round_labels[cursor - 1] not in LEADER_TIMEOUT_APPEAL_LABELS
-                ):
-                    break
-                previous_normal = cursor - 2
-                while previous_normal >= 0 and is_appeal_round(
-                    round_labels[previous_normal]
-                ):
-                    previous_normal -= 1
-                if previous_normal < 0:
-                    break
-                cursor = previous_normal
-            rotations_for_quote = max(initial_rotations - used_total, 0)
+            attempt_basis = "configured_next_normal_round"
+            rotations_for_quote = 0
+            if rotations is not None and (appeal_index + 1) < len(rotations):
+                rotations_for_quote = rotations[appeal_index + 1]
         else:
             # Undetermined appeal: full next normal round (round + 2 schedule)
             committee_size = get_normal_round_size(appeal_index + 1)

--- a/src/fee_simulator/core/majority.py
+++ b/src/fee_simulator/core/majority.py
@@ -153,7 +153,10 @@ def who_is_in_vote_majority(
         if normalize_vote(vote) == majority_vote:
             majority_addresses.append(addr)
 
-    minority_addresses = list(set(rotation.keys()) - set(majority_addresses))
+    majority_address_set = set(majority_addresses)
+    minority_addresses = [
+        addr for addr in rotation.keys() if addr not in majority_address_set
+    ]
     return majority_addresses, minority_addresses
 
 

--- a/src/fee_simulator/core/path_to_transaction.py
+++ b/src/fee_simulator/core/path_to_transaction.py
@@ -476,9 +476,7 @@ def path_to_transaction_results(
                 # L % (N-1) of the reduced array becomes the new leader —
                 # NO new validators are selected. Chained timeout appeals
                 # therefore shrink the committee each time (5 -> 4 -> 3 ...).
-                timed_out_committee = list(
-                    rounds[-2].rotations[-1].votes.keys()
-                )
+                timed_out_committee = list(rounds[-2].rotations[-1].votes.keys())
                 leader_idx = 0  # the simulator always seats the leader first
                 reduced = (
                     timed_out_committee[:leader_idx]
@@ -545,9 +543,7 @@ def path_to_transaction_results(
                     if not committee:
                         break
                     entry_leader = committee[0]
-                    rotation_votes = make_rotation_votes(
-                        len(committee), committee
-                    )
+                    rotation_votes = make_rotation_votes(len(committee), committee)
                     rotations_list.append(Rotation(votes=rotation_votes))
                     previous_leaders.append(entry_leader)
 
@@ -584,8 +580,12 @@ def path_to_transaction_results(
                 votes = dict(last_rot.votes)
                 # Make the last num_idle validators IDLE
                 validator_addrs = [
-                    addr for addr in votes.keys()
-                    if not (isinstance(votes[addr], list) and votes[addr][0] in ["LEADER_RECEIPT", "LEADER_TIMEOUT"])
+                    addr
+                    for addr in votes.keys()
+                    if not (
+                        isinstance(votes[addr], list)
+                        and votes[addr][0] in ["LEADER_RECEIPT", "LEADER_TIMEOUT"]
+                    )
                 ]
                 for idle_idx in range(min(num_idle, len(validator_addrs))):
                     idle_addr = validator_addrs[-(idle_idx + 1)]
@@ -610,16 +610,24 @@ def path_to_transaction_results(
         if round_obj.rotations and round_obj.rotations[-1].votes:
             prev_majority = compute_majority(round_obj.rotations[-1].votes)
 
-    # Create budget with actual rotation counts
-    budget_rotations = []
+    # The latest Consensus has two distinct rotation concepts:
+    # - feesDistribution.rotations is the funded schedule;
+    # - RoundsStorage.rotationsLeft is live runtime capacity.
+    # Every normal round is seeded from one transaction-wide capacity clamped
+    # to the smallest funded entry. The minimal valid schedule for this path is
+    # therefore uniform at the largest number of rotations actually exercised.
+    rotations_used = []
     for nc in range(normal_count):
-        budget_rotations.append(rotation_counts.get(nc, 0))
+        rotations_used.append(rotation_counts.get(nc, 0))
+    initial_rotation_capacity = max(rotations_used, default=0)
+    funded_rotations = [initial_rotation_capacity] * normal_count
 
     budget = TransactionBudget(
         leaderTimeout=leader_timeout,
         validatorsTimeout=validators_timeout,
         appealRounds=appeal_count,
-        rotations=budget_rotations,
+        rotations=funded_rotations,
+        rotationsUsed=rotations_used,
         senderAddress=sender_address,
         appeals=appeals,
         staking_distribution="constant",

--- a/src/fee_simulator/core/path_to_transaction.py
+++ b/src/fee_simulator/core/path_to_transaction.py
@@ -610,17 +610,17 @@ def path_to_transaction_results(
         if round_obj.rotations and round_obj.rotations[-1].votes:
             prev_majority = compute_majority(round_obj.rotations[-1].votes)
 
-    # The latest Consensus has two distinct rotation concepts:
-    # - feesDistribution.rotations is the funded schedule;
-    # - RoundsStorage.rotationsLeft is live runtime capacity.
-    # Every normal round is seeded from one transaction-wide capacity clamped
-    # to the smallest funded entry. The minimal valid schedule for this path is
-    # therefore uniform at the largest number of rotations actually exercised.
+    # The latest Consensus has three related rotation values:
+    # - feesDistribution.rotations is the exact per-normal-round funded schedule;
+    # - Transaction.initialRotations is a transaction-wide ceiling; and
+    # - RoundsStorage.rotationsLeft is the live remainder for one normal round.
+    # The minimal funded schedule for a generated path is therefore the exact
+    # number of rotations exercised at each normal-round ordinal. Consensus
+    # derives the transaction-wide ceiling from the largest entry.
     rotations_used = []
     for nc in range(normal_count):
         rotations_used.append(rotation_counts.get(nc, 0))
-    initial_rotation_capacity = max(rotations_used, default=0)
-    funded_rotations = [initial_rotation_capacity] * normal_count
+    funded_rotations = list(rotations_used)
 
     budget = TransactionBudget(
         leaderTimeout=leader_timeout,

--- a/src/fee_simulator/core/refunds.py
+++ b/src/fee_simulator/core/refunds.py
@@ -64,6 +64,7 @@ def compute_sender_refund(
             round_labels=round_labels,
             appeal_round_index=i,
             rotations=transaction_budget.rotations,
+            rotations_used=transaction_budget.rotationsUsed,
         )
 
     earned_total = 0

--- a/src/fee_simulator/core/round_fee_distribution/appeal_leader_successful.py
+++ b/src/fee_simulator/core/round_fee_distribution/appeal_leader_successful.py
@@ -46,6 +46,7 @@ def apply_appeal_leader_successful(
         validators_timeout=budget.validatorsTimeout,
         round_labels=round_labels,
         rotations=budget.rotations,
+        rotations_used=budget.rotationsUsed,
     )
     events.append(
         FeeEvent(

--- a/src/fee_simulator/core/round_fee_distribution/appeal_leader_timeout_successful.py
+++ b/src/fee_simulator/core/round_fee_distribution/appeal_leader_timeout_successful.py
@@ -46,6 +46,7 @@ def apply_appeal_leader_timeout_successful(
         validators_timeout=budget.validatorsTimeout,
         round_labels=round_labels,
         rotations=budget.rotations,
+        rotations_used=budget.rotationsUsed,
     )
     events.append(
         FeeEvent(

--- a/src/fee_simulator/core/round_fee_distribution/appeal_validator_successful.py
+++ b/src/fee_simulator/core/round_fee_distribution/appeal_validator_successful.py
@@ -53,6 +53,7 @@ def apply_appeal_validator_successful(
         validators_timeout=budget.validatorsTimeout,
         round_labels=round_labels,
         rotations=budget.rotations,
+        rotations_used=budget.rotationsUsed,
     )
     events.append(
         FeeEvent(

--- a/src/fee_simulator/core/round_fee_distribution/appeal_validator_unsuccessful.py
+++ b/src/fee_simulator/core/round_fee_distribution/appeal_validator_unsuccessful.py
@@ -61,9 +61,7 @@ def apply_appeal_validator_unsuccessful(
         aligned_addresses = list(votes.keys())
         minority_addresses = []
     else:
-        aligned_addresses, minority_addresses = who_is_in_vote_majority(
-            votes, majority
-        )
+        aligned_addresses, minority_addresses = who_is_in_vote_majority(votes, majority)
 
     normal_round_index = find_previous_normal_round(round_index, round_labels)
     if normal_round_index is None:
@@ -76,6 +74,7 @@ def apply_appeal_validator_unsuccessful(
         round_labels=round_labels,
         appeal_round_index=round_index,
         rotations=budget.rotations,
+        rotations_used=budget.rotationsUsed,
     )
 
     pool = budget.validatorsTimeout * len(votes) + appeal_bond

--- a/src/fee_simulator/core/round_fee_distribution/equal_split.py
+++ b/src/fee_simulator/core/round_fee_distribution/equal_split.py
@@ -73,6 +73,7 @@ def apply_equal_split(
             validators_timeout=budget.validatorsTimeout,
             round_labels=round_labels,
             rotations=budget.rotations,
+            rotations_used=budget.rotationsUsed,
             appeal_round_index=round_index - 1,
         )
 

--- a/src/fee_simulator/core/round_fee_distribution/leader_timeout_150_previous_normal_round.py
+++ b/src/fee_simulator/core/round_fee_distribution/leader_timeout_150_previous_normal_round.py
@@ -40,6 +40,7 @@ def apply_leader_timeout_150_previous_normal_round(
         validators_timeout=budget.validatorsTimeout,
         round_labels=round_labels,
         rotations=budget.rotations,
+        rotations_used=budget.rotationsUsed,
     )
 
     # Award the leader 150% of leaderTimeout

--- a/src/fee_simulator/core/round_fee_distribution/leader_timeout_50_percent.py
+++ b/src/fee_simulator/core/round_fee_distribution/leader_timeout_50_percent.py
@@ -58,7 +58,9 @@ def apply_leader_timeout_50_percent(
             appealant_address = budget.appeals[appeal_index].appealantAddress
 
             # Find the most recent normal round before the appeal
-            normal_round_index = find_previous_normal_round(round_index - 1, round_labels)
+            normal_round_index = find_previous_normal_round(
+                round_index - 1, round_labels
+            )
             if normal_round_index is None:
                 normal_round_index = round_index - 2  # Default
 
@@ -70,6 +72,7 @@ def apply_leader_timeout_50_percent(
                 round_labels=round_labels,
                 appeal_round_index=round_index - 1,  # The unsuccessful appeal round
                 rotations=budget.rotations,
+                rotations_used=budget.rotationsUsed,
             )
 
             # Use the burn computation method to calculate how much to burn

--- a/src/fee_simulator/core/round_fee_distribution/leader_timeout_50_previous_appeal_bond.py
+++ b/src/fee_simulator/core/round_fee_distribution/leader_timeout_50_previous_appeal_bond.py
@@ -48,6 +48,7 @@ def apply_leader_timeout_50_previous_appeal_bond(
         round_labels=round_labels,
         appeal_round_index=round_index - 1,
         rotations=budget.rotations,
+        rotations_used=budget.rotationsUsed,
     )
 
     leader_share = appeal_bond // 2

--- a/src/fee_simulator/core/round_fee_distribution/normal_round.py
+++ b/src/fee_simulator/core/round_fee_distribution/normal_round.py
@@ -138,7 +138,9 @@ def apply_normal_round(
             appealant_address = budget.appeals[appeal_index].appealantAddress
 
             # Find the most recent normal round before the appeal
-            normal_round_index = find_previous_normal_round(round_index - 1, round_labels)
+            normal_round_index = find_previous_normal_round(
+                round_index - 1, round_labels
+            )
             if normal_round_index is None:
                 normal_round_index = round_index - 2  # Default
 
@@ -152,6 +154,7 @@ def apply_normal_round(
                 round_labels=round_labels,
                 appeal_round_index=round_index - 1,  # The unsuccessful appeal round
                 rotations=budget.rotations,
+                rotations_used=budget.rotationsUsed,
             )
 
             # Use the burn computation method to calculate how much to burn

--- a/src/fee_simulator/core/round_fee_distribution/skip_round.py
+++ b/src/fee_simulator/core/round_fee_distribution/skip_round.py
@@ -40,7 +40,9 @@ def apply_skip_round(
             appealant_address = budget.appeals[appeal_index].appealantAddress
 
             # Find the most recent normal round before the appeal
-            normal_round_index = find_previous_normal_round(round_index - 1, round_labels)
+            normal_round_index = find_previous_normal_round(
+                round_index - 1, round_labels
+            )
             if normal_round_index is None:
                 normal_round_index = round_index - 2  # Default
 
@@ -52,6 +54,7 @@ def apply_skip_round(
                 round_labels=round_labels,
                 appeal_round_index=round_index - 1,  # The unsuccessful appeal round
                 rotations=budget.rotations,
+                rotations_used=budget.rotationsUsed,
             )
 
             # Use the burn computation method to calculate how much to burn

--- a/src/fee_simulator/core/round_fee_distribution/split_previous_appeal_bond.py
+++ b/src/fee_simulator/core/round_fee_distribution/split_previous_appeal_bond.py
@@ -55,6 +55,7 @@ def apply_split_previous_appeal_bond(
         validators_timeout=budget.validatorsTimeout,
         round_labels=round_labels,
         rotations=budget.rotations,
+        rotations_used=budget.rotationsUsed,
         appeal_round_index=round_index - 1,
     )
 
@@ -63,9 +64,7 @@ def apply_split_previous_appeal_bond(
         aligned_addresses = list(votes.keys())
         minority_addresses = []
     else:
-        aligned_addresses, minority_addresses = who_is_in_vote_majority(
-            votes, majority
-        )
+        aligned_addresses, minority_addresses = who_is_in_vote_majority(votes, majority)
 
     bond_share = split_amount(appeal_bond, len(aligned_addresses))
     for addr in aligned_addresses:

--- a/src/fee_simulator/core/transaction_processing.py
+++ b/src/fee_simulator/core/transaction_processing.py
@@ -100,6 +100,7 @@ def process_transaction(
                         round_labels=labels,  # Pass labels
                         appeal_round_index=i,  # Pass the current appeal round index
                         rotations=transaction_budget.rotations,
+                        rotations_used=transaction_budget.rotationsUsed,
                     )
                     fee_events.append(
                         FeeEvent(

--- a/src/fee_simulator/protocol/models.py
+++ b/src/fee_simulator/protocol/models.py
@@ -101,7 +101,13 @@ class TransactionBudget(BaseModel):
     leaderTimeout: int = Field(ge=0)
     validatorsTimeout: int = Field(ge=0)
     appealRounds: int = Field(ge=0)
+    # Funded rotation allowance for each normal round. Consensus seeds one
+    # common runtime capacity from the minimum entry in this schedule.
     rotations: List[int]
+    # Rotations actually consumed in each normal round. Kept separate from the
+    # funded allowance because LeaderTimeout bonds use the live remainder while
+    # Undetermined bonds use a future configured schedule entry.
+    rotationsUsed: Optional[List[int]] = None
     senderAddress: str
     appeals: Optional[List[Appeal]] = []
     staking_distribution: Literal["constant", "normal"] = Field(default="constant")
@@ -119,6 +125,10 @@ class TransactionBudget(BaseModel):
         # Rotations are indexed by normal round index, so we just need at least one
         if len(self.rotations) == 0:
             raise ValueError("Must have at least one rotation")
+        if self.rotationsUsed is not None and len(self.rotationsUsed) != len(
+            self.rotations
+        ):
+            raise ValueError("rotationsUsed must align with rotations")
         return self
 
     @model_validator(mode="after")

--- a/src/fee_simulator/protocol/models.py
+++ b/src/fee_simulator/protocol/models.py
@@ -101,12 +101,12 @@ class TransactionBudget(BaseModel):
     leaderTimeout: int = Field(ge=0)
     validatorsTimeout: int = Field(ge=0)
     appealRounds: int = Field(ge=0)
-    # Funded rotation allowance for each normal round. Consensus seeds one
-    # common runtime capacity from the minimum entry in this schedule.
+    # Funded rotation allowance for each normal-round ordinal. Consensus keeps
+    # a transaction-wide ceiling, then seeds each normal round with the lesser
+    # of that ceiling and this round's exact funded entry.
     rotations: List[int]
-    # Rotations actually consumed in each normal round. Kept separate from the
-    # funded allowance because LeaderTimeout bonds use the live remainder while
-    # Undetermined bonds use a future configured schedule entry.
+    # Rotations actually consumed in each normal round. Kept as provenance;
+    # appeal admission prices configured future work, not the live remainder.
     rotationsUsed: Optional[List[int]] = None
     senderAddress: str
     appeals: Optional[List[Appeal]] = []

--- a/src/fee_simulator/specification/invariants/definitions/appeal_bond_consistency.py
+++ b/src/fee_simulator/specification/invariants/definitions/appeal_bond_consistency.py
@@ -57,6 +57,7 @@ def check_appeal_bond_consistency(
                         round_labels=round_labels,
                         appeal_round_index=i,
                         rotations=transaction_budget.rotations,
+                        rotations_used=transaction_budget.rotationsUsed,
                     )
                     expected_size = None
                 else:

--- a/src/fee_simulator/specification/invariants/definitions/appeal_bond_coverage.py
+++ b/src/fee_simulator/specification/invariants/definitions/appeal_bond_coverage.py
@@ -44,6 +44,7 @@ def check_appeal_bond_coverage(
                 round_labels=round_labels,
                 appeal_round_index=i,
                 rotations=transaction_budget.rotations,
+                rotations_used=transaction_budget.rotationsUsed,
             )
 
             # Find actual bond paid

--- a/src/fee_simulator/specification/invariants/definitions/appellant_consistency.py
+++ b/src/fee_simulator/specification/invariants/definitions/appellant_consistency.py
@@ -72,6 +72,7 @@ def check_appellant_consistency(
                 round_labels=round_labels,
                 appeal_round_index=round_idx,
                 rotations=transaction_budget.rotations,
+                rotations_used=transaction_budget.rotationsUsed,
             )
             expected_size = None
         else:

--- a/src/fee_simulator/specification/state_machine/graph.py
+++ b/src/fee_simulator/specification/state_machine/graph.py
@@ -5,7 +5,6 @@ Graph data structure for the fee simulator round combinations.
 from types import MappingProxyType
 from typing import Dict, List, Any
 
-
 # The dependency graph as pure data
 # Using MappingProxyType for immutability
 _GRAPH_DATA = {
@@ -83,6 +82,32 @@ _GRAPH_DATA = {
 
 # Expose immutable view of the graph
 TRANSACTION_GRAPH: Dict[str, List[str]] = MappingProxyType(_GRAPH_DATA)
+
+
+def is_protocol_valid_path(path: List[str]) -> bool:
+    """Enforce lifecycle rules that need path history, not one graph edge.
+
+    A successful validator-review jury is followed by exactly one terminal
+    normal recomputation. That terminal decision ends this appeal ladder and
+    cannot itself be appealed again.
+    """
+
+    terminal_normal_seen = False
+    expect_terminal_normal = False
+    for node in path:
+        if terminal_normal_seen and node != "END":
+            return False
+        if expect_terminal_normal:
+            if node == "END":
+                return True
+            if "APPEAL" in node or node == "START":
+                return False
+            expect_terminal_normal = False
+            terminal_normal_seen = True
+            continue
+        if node == "VALIDATOR_APPEAL_SUCCESSFUL":
+            expect_terminal_normal = True
+    return True
 
 
 def get_graph() -> Dict[str, List[str]]:

--- a/tests/fee_distributions/test_rotations_idleness_equal_split.py
+++ b/tests/fee_distributions/test_rotations_idleness_equal_split.py
@@ -16,7 +16,10 @@ from src.fee_simulator.core.transaction_processing import process_transaction
 from src.fee_simulator.core.round_labeling import label_rounds
 from src.fee_simulator.core.path_to_transaction import path_to_transaction_results
 from src.fee_simulator.core.majority import compute_majority
-from src.fee_simulator.core.idleness import replace_idle_participants, resolve_partial_votes
+from src.fee_simulator.core.idleness import (
+    replace_idle_participants,
+    resolve_partial_votes,
+)
 from src.fee_simulator.utils import compute_total_cost, generate_random_eth_address
 from src.fee_simulator.metrics.address_metrics import (
     compute_all_zeros,
@@ -175,12 +178,10 @@ class TestRotations:
         )
 
         # Should process without errors and pass invariants
-        check_all_invariants(
-            fee_events, budget, transaction_results, round_labels
-        )
+        check_all_invariants(fee_events, budget, transaction_results, round_labels)
 
-    def test_budget_rotation_counts_correct(self):
-        """Verify that budget.rotations correctly reflects rotation_counts."""
+    def test_budget_separates_funded_capacity_from_actual_rotation_counts(self):
+        """The generated path is executable under Consensus's global clamp."""
         path = [
             "START",
             "LEADER_RECEIPT_MAJORITY_AGREE",
@@ -198,7 +199,8 @@ class TestRotations:
             rotation_counts={0: 2, 1: 0},  # First normal round has 2 rotations
         )
 
-        assert budget.rotations == [2, 0]
+        assert budget.rotations == [2, 2]
+        assert budget.rotationsUsed == [2, 0]
 
     def test_total_cost_formula_with_rotations(self):
         """
@@ -329,7 +331,9 @@ class TestIdleness:
         reserve_votes = {addresses_pool[5]: "AGREE"}
 
         transaction_results = TransactionRoundResults(
-            rounds=[Round(rotations=[Rotation(votes=votes, reserve_votes=reserve_votes)])]
+            rounds=[
+                Round(rotations=[Rotation(votes=votes, reserve_votes=reserve_votes)])
+            ]
         )
 
         event_sequence = EventSequence()
@@ -353,7 +357,10 @@ class TestIdleness:
 
         # Idle validator should be replaced
         final_votes = new_results.rounds[0].rotations[-1].votes
-        assert addresses_pool[4] not in final_votes or final_votes.get(addresses_pool[4]) != "IDLE"
+        assert (
+            addresses_pool[4] not in final_votes
+            or final_votes.get(addresses_pool[4]) != "IDLE"
+        )
 
         # Should have a slashing event for the idle validator
         slash_events = [e for e in new_events if e.slashed > 0]
@@ -469,10 +476,7 @@ class TestEqualSplit:
         assert round_labels[2] == "EQUAL_SPLIT"
 
         # Get EQUAL_SPLIT round events
-        equal_split_events = [
-            e for e in fee_events
-            if e.round_label == "EQUAL_SPLIT"
-        ]
+        equal_split_events = [e for e in fee_events if e.round_label == "EQUAL_SPLIT"]
 
         # Leader should earn leaderTimeout
         leader_events = [e for e in equal_split_events if e.role == "LEADER"]
@@ -520,9 +524,7 @@ class TestEqualSplit:
         )
 
         # This should pass all 24 invariants
-        check_all_invariants(
-            fee_events, budget, transaction_results, round_labels
-        )
+        check_all_invariants(fee_events, budget, transaction_results, round_labels)
 
     def test_equal_split_vs_split_bond_differentiation(self, verbose, debug):
         """
@@ -657,6 +659,4 @@ class TestIntegration:
                 transaction_results=transaction_results,
                 transaction_budget=budget,
             )
-            check_all_invariants(
-                fee_events, budget, transaction_results, round_labels
-            )
+            check_all_invariants(fee_events, budget, transaction_results, round_labels)

--- a/tests/fee_distributions/test_rotations_idleness_equal_split.py
+++ b/tests/fee_distributions/test_rotations_idleness_equal_split.py
@@ -180,8 +180,8 @@ class TestRotations:
         # Should process without errors and pass invariants
         check_all_invariants(fee_events, budget, transaction_results, round_labels)
 
-    def test_budget_separates_funded_capacity_from_actual_rotation_counts(self):
-        """The generated path is executable under Consensus's global clamp."""
+    def test_budget_tracks_exact_per_round_rotation_requirements(self):
+        """Generated paths use the minimal executable Consensus schedule."""
         path = [
             "START",
             "LEADER_RECEIPT_MAJORITY_AGREE",
@@ -199,8 +199,9 @@ class TestRotations:
             rotation_counts={0: 2, 1: 0},  # First normal round has 2 rotations
         )
 
-        assert budget.rotations == [2, 2]
+        assert budget.rotations == [2, 0]
         assert budget.rotationsUsed == [2, 0]
+        assert max(budget.rotations) == 2  # transaction-wide runtime ceiling
 
     def test_total_cost_formula_with_rotations(self):
         """

--- a/tests/protocol/test_appeal_bond_quotes.py
+++ b/tests/protocol/test_appeal_bond_quotes.py
@@ -44,7 +44,7 @@ def test_undetermined_appeal_quote_exposes_next_round_and_rotation_components():
 def test_later_undetermined_quote_uses_normal_round_ordinal():
     labels = [
         "NORMAL_ROUND",
-        "APPEAL_VALIDATOR_SUCCESSFUL",
+        "APPEAL_LEADER_UNSUCCESSFUL",
         "NORMAL_ROUND",
         "APPEAL_LEADER_SUCCESSFUL",
     ]
@@ -75,7 +75,7 @@ def test_leader_timeout_quote_keeps_the_configured_source_round_basis():
 
     assert quote.committee_basis == "configured_source_round"
     assert quote.committee_size == 5
-    assert quote.attempt_basis == "live_source_round"
+    assert quote.attempt_basis == "configured_next_normal_round"
     assert quote.rotations_value == 0
     assert quote.attempts == 1
     assert quote.leader_component == 100
@@ -83,7 +83,7 @@ def test_leader_timeout_quote_keeps_the_configured_source_round_basis():
     assert quote.total == 1_100
 
 
-def test_leader_timeout_quote_subtracts_rotations_used_from_funded_capacity():
+def test_leader_timeout_quote_uses_next_funded_round_independently_of_prior_usage():
     labels = ["NORMAL_ROUND", "APPEAL_LEADER_TIMEOUT_SUCCESSFUL"]
 
     quote = compute_appeal_bond_quote(
@@ -95,12 +95,12 @@ def test_leader_timeout_quote_subtracts_rotations_used_from_funded_capacity():
         rotations_used=[1, 0],
     )
 
-    assert quote.rotations_value == 1
-    assert quote.attempts == 2
-    assert quote.total == 2_200
+    assert quote.rotations_value == 2
+    assert quote.attempts == 3
+    assert quote.total == 3_300
 
 
-def test_chained_timeout_quote_inherits_the_prior_rounds_live_remainder():
+def test_chained_timeout_quote_uses_each_next_normal_round_schedule_entry():
     labels = [
         "NORMAL_ROUND",
         "APPEAL_LEADER_TIMEOUT_SUCCESSFUL",
@@ -114,7 +114,7 @@ def test_chained_timeout_quote_inherits_the_prior_rounds_live_remainder():
         200,
         labels,
         appeal_round_index=3,
-        rotations=[3, 3],
+        rotations=[3, 2, 1],
         rotations_used=[1, 1],
     )
 

--- a/tests/protocol/test_appeal_bond_quotes.py
+++ b/tests/protocol/test_appeal_bond_quotes.py
@@ -11,6 +11,8 @@ def test_validator_appeal_quote_exposes_the_appeal_committee_basis():
 
     assert quote.committee_basis == "configured_appeal_round"
     assert quote.committee_size == 7
+    assert quote.attempt_basis == "single_appeal_jury"
+    assert quote.rotations_value == 0
     assert quote.attempts == 1
     assert quote.leader_component == 0
     assert quote.validator_component == 1_400
@@ -31,10 +33,39 @@ def test_undetermined_appeal_quote_exposes_next_round_and_rotation_components():
 
     assert quote.committee_basis == "configured_next_normal_round"
     assert quote.committee_size == 11
+    assert quote.attempt_basis == "configured_next_normal_round"
+    assert quote.rotations_value == 2
     assert quote.attempts == 3
     assert quote.leader_component == 300
     assert quote.validator_component == 6_600
     assert quote.total == 6_900
+
+
+def test_later_undetermined_quote_uses_normal_round_ordinal():
+    labels = [
+        "NORMAL_ROUND",
+        "APPEAL_VALIDATOR_SUCCESSFUL",
+        "NORMAL_ROUND",
+        "APPEAL_LEADER_SUCCESSFUL",
+    ]
+
+    quote = compute_appeal_bond_quote(
+        2,
+        100,
+        200,
+        labels,
+        appeal_round_index=3,
+        rotations=[0, 1, 2],
+        rotations_used=[0, 0, 0],
+    )
+
+    # Raw round 4 is normal-round ordinal 2, so rotations[2] prices three
+    # attempts at the configured 23-seat committee.
+    assert quote.source_round_index == 2
+    assert quote.committee_size == 23
+    assert quote.rotations_value == 2
+    assert quote.attempts == 3
+    assert quote.total == 3 * (100 + 23 * 200)
 
 
 def test_leader_timeout_quote_keeps_the_configured_source_round_basis():
@@ -44,7 +75,50 @@ def test_leader_timeout_quote_keeps_the_configured_source_round_basis():
 
     assert quote.committee_basis == "configured_source_round"
     assert quote.committee_size == 5
+    assert quote.attempt_basis == "live_source_round"
+    assert quote.rotations_value == 0
     assert quote.attempts == 1
     assert quote.leader_component == 100
     assert quote.validator_component == 1_000
     assert quote.total == 1_100
+
+
+def test_leader_timeout_quote_subtracts_rotations_used_from_funded_capacity():
+    labels = ["NORMAL_ROUND", "APPEAL_LEADER_TIMEOUT_SUCCESSFUL"]
+
+    quote = compute_appeal_bond_quote(
+        0,
+        100,
+        200,
+        labels,
+        rotations=[2, 2],
+        rotations_used=[1, 0],
+    )
+
+    assert quote.rotations_value == 1
+    assert quote.attempts == 2
+    assert quote.total == 2_200
+
+
+def test_chained_timeout_quote_inherits_the_prior_rounds_live_remainder():
+    labels = [
+        "NORMAL_ROUND",
+        "APPEAL_LEADER_TIMEOUT_SUCCESSFUL",
+        "NORMAL_ROUND",
+        "APPEAL_LEADER_TIMEOUT_SUCCESSFUL",
+    ]
+
+    quote = compute_appeal_bond_quote(
+        2,
+        100,
+        200,
+        labels,
+        appeal_round_index=3,
+        rotations=[3, 3],
+        rotations_used=[1, 1],
+    )
+
+    assert quote.committee_size == 11
+    assert quote.rotations_value == 1
+    assert quote.attempts == 2
+    assert quote.total == 4_600

--- a/tests/protocol/test_appeal_bond_quotes.py
+++ b/tests/protocol/test_appeal_bond_quotes.py
@@ -1,0 +1,50 @@
+from src.fee_simulator.core.bond_computing import (
+    compute_appeal_bond,
+    compute_appeal_bond_quote,
+)
+
+
+def test_validator_appeal_quote_exposes_the_appeal_committee_basis():
+    labels = ["NORMAL_ROUND", "APPEAL_VALIDATOR_SUCCESSFUL"]
+
+    quote = compute_appeal_bond_quote(0, 100, 200, labels)
+
+    assert quote.committee_basis == "configured_appeal_round"
+    assert quote.committee_size == 7
+    assert quote.attempts == 1
+    assert quote.leader_component == 0
+    assert quote.validator_component == 1_400
+    assert quote.total == 1_400
+    assert compute_appeal_bond(0, 100, 200, labels) == quote.total
+
+
+def test_undetermined_appeal_quote_exposes_next_round_and_rotation_components():
+    labels = ["NORMAL_ROUND", "APPEAL_LEADER_SUCCESSFUL"]
+
+    quote = compute_appeal_bond_quote(
+        0,
+        100,
+        200,
+        labels,
+        rotations=[0, 2],
+    )
+
+    assert quote.committee_basis == "configured_next_normal_round"
+    assert quote.committee_size == 11
+    assert quote.attempts == 3
+    assert quote.leader_component == 300
+    assert quote.validator_component == 6_600
+    assert quote.total == 6_900
+
+
+def test_leader_timeout_quote_keeps_the_configured_source_round_basis():
+    labels = ["NORMAL_ROUND", "APPEAL_LEADER_TIMEOUT_SUCCESSFUL"]
+
+    quote = compute_appeal_bond_quote(0, 100, 200, labels, rotations=[0, 0])
+
+    assert quote.committee_basis == "configured_source_round"
+    assert quote.committee_size == 5
+    assert quote.attempts == 1
+    assert quote.leader_component == 100
+    assert quote.validator_component == 1_000
+    assert quote.total == 1_100

--- a/tests/protocol/test_majority_ordering.py
+++ b/tests/protocol/test_majority_ordering.py
@@ -1,0 +1,15 @@
+from src.fee_simulator.core.majority import who_is_in_vote_majority
+
+
+def test_vote_minority_preserves_committee_order():
+    rotation = {
+        "leader": ["LEADER_RECEIPT", "AGREE"],
+        "minority-1": "DISAGREE",
+        "majority": "AGREE",
+        "minority-2": "TIMEOUT",
+    }
+
+    majority, minority = who_is_in_vote_majority(rotation, "AGREE")
+
+    assert majority == ["leader", "majority"]
+    assert minority == ["minority-1", "minority-2"]

--- a/tests/protocol/test_state_machine_lifecycle.py
+++ b/tests/protocol/test_state_machine_lifecycle.py
@@ -1,0 +1,27 @@
+from src.fee_simulator.specification.state_machine.graph import is_protocol_valid_path
+
+
+def test_successful_validator_appeal_allows_one_terminal_normal_round():
+    assert is_protocol_valid_path(
+        [
+            "START",
+            "LEADER_RECEIPT_MAJORITY_AGREE",
+            "VALIDATOR_APPEAL_SUCCESSFUL",
+            "LEADER_RECEIPT_UNDETERMINED",
+            "END",
+        ]
+    )
+
+
+def test_terminal_normal_decision_cannot_reopen_the_appeal_ladder():
+    assert not is_protocol_valid_path(
+        [
+            "START",
+            "LEADER_RECEIPT_MAJORITY_AGREE",
+            "VALIDATOR_APPEAL_SUCCESSFUL",
+            "LEADER_RECEIPT_UNDETERMINED",
+            "LEADER_APPEAL_SUCCESSFUL",
+            "LEADER_RECEIPT_MAJORITY_AGREE",
+            "END",
+        ]
+    )


### PR DESCRIPTION
## Delivery context

Stack: #28 → #29 → this PR  
Base: `fix/appeal-economics-oracle-v2` at `58115643f733eedfa331f1b78243f4b373482704`  
Consensus consumers: genlayerlabs/genlayer-consensus#1381 and #1388

## Outcome

This layer exports the simulator expectation at every appeal-admission boundary instead of checking only terminal settlement.

Each checkpoint records source status/raw round, configured committee basis, live selectable/capacity-limited jury count, funded/used rotations, remaining attempts, leader/validator components, and exact minimum appeal bond.

The leader-timeout rule is explicit: replay membership excludes the timed-out leader, while bond pricing retains the configured source-round validator count and applies the live remaining-attempt count. Later raw rounds use normal-round rotation ordinals.

## Validation

- rebased full simulator suite: **1,031 passed, 5 skipped**;
- cross-family vector sweep: **5,601 cases**, no negative sender outcomes;
- compact consumer campaign: **32 cases / 32 unique signatures**;
- required Consensus consumer campaign: **24 passing**;
- diff checks: clean.

Current head: `09fa7790f44a7d809eb9b429d8ca900e1b876c38`. The stack reports no rebase requirement.